### PR TITLE
Code edits for 'spid' map finalization

### DIFF
--- a/hc/Impulse commands.txt
+++ b/hc/Impulse commands.txt
@@ -1,0 +1,35 @@
+1 à 4	Change weapon (or RPG answers: Inky custom)
+9	All weapons
+10
+11
+12
+13
+14
+15	Kill/touch or use aimed entity
+16	Kill all monsters
+17	Remove aimed entity
+19	Infinite mana (Inky custom: previously was granted automatically by god mode, which is no more)
+22
+23
+23
+25	Gimme a Tome Of Power
+27
+28
+32
+33
+35
+36
+37
+39
+40
+41
+42
+43
+44
+99
+100 à 115
+171 à 175
+177
+178
+254
+255

--- a/hc/chunk.hc
+++ b/hc/chunk.hc
@@ -780,6 +780,7 @@ void chunk_death (void)
 	if(self.classname=="monster_eidolon")
 		return;
 
+	self.health = 0; //Inky 20220109 Any any risk of tunaway loop between chunk_death and SUB_UseTargets
 	SUB_UseTargets();
 	
 	/*20210703 bmFbr's shadows code*/

--- a/hc/client.hc
+++ b/hc/client.hc
@@ -1722,6 +1722,8 @@ void() PlayerPreThink =
 {
 	vector	spot1, spot2;	
 
+	if(player==world) player=self;
+	
 	self.friction = 1;
 
 	if ((self.health<=0) && (self.movetype!=MOVETYPE_NOCLIP))
@@ -1765,10 +1767,9 @@ void() PlayerPreThink =
 	//Inky 20211111 START - liquid func_train_mp support
 	// Set cshift back to normal if eyes are out of liquid func_train_mp
 	if (self.watertime < time) {
-		if (self.watershift) {
-			stuffcmd(self, "v_cshift 130 80 50 0\n");
+		stuffcmd(self, "v_cshift 130 80 50 0\n");
+		if (self.watershift)
 			self.watershift = FALSE;
-		}
 	}
 
 	if (self.zerogtime < time)
@@ -1893,7 +1894,7 @@ void() PlayerPreThink =
 		self.velocity = '0 0 0';
 
 	//// TEMP::God Mode Mana Save
-	if (self.flags & FL_GODMODE)
+	if (self.switchshadstyle & FL_INFINITE_MANA)
 	{
 		self.bluemana = self.max_mana;
 		self.greenmana = self.max_mana;

--- a/hc/constant.hc
+++ b/hc/constant.hc
@@ -117,6 +117,7 @@ float FL_ARCHIVE_OVERRIDE		= 1048576;	// quake 2 thingy
 float FL_CLASS_DEPENDENT		= 2097152;  // model will appear different to each player
 float FL_SPECIAL_ABILITY1		= 4194304;  // has 1st special ability
 float FL_SPECIAL_ABILITY2		= 8388608;  // has 2nd special ability
+float FL_INFINITE_MANA			= 16777216; // Infinite mana
 
 //edict.flags2
 //FIXME: Shielded and small may be able to be determined by

--- a/hc/impulse.hc
+++ b/hc/impulse.hc
@@ -355,6 +355,11 @@ void() ImpulseCommands =
 
 	if (self.impulse == 9&&skill<3)
 		CheatCommand ();
+	else if (self.impulse == 19&&skill<3)
+	{
+		self.switchshadstyle (+) FL_INFINITE_MANA;
+		self.impulse = 0;
+	}
 	else if(self.impulse==177)//Make BBOX model
 		if(self.movechain.model=="models/playrbox.mdl")
 		{

--- a/hc/plats_mp.hc
+++ b/hc/plats_mp.hc
@@ -586,6 +586,13 @@ ANGLE_WAIT - Train will not change angles until it reached path_corner, and will
 MODEL_AND_BRUSH - Trains with weaponmodel set keep their brushes drawn as well
 PLAYER_MODEL - weaponmodel is automatically set to the relevant player model depending on the current class
 
+self.decap:
+0 - Initial state when spawned or "returned" (used for the second time -first time being the train activation- with spawnflags & TRAIN_RETURN 'Return')
+1 - Moving
+2 - Stopped (like spawnflags & TRAIN_WAITTRIG 'Toggle')
+Not so clear what difference is self.decap==0 versus self.decap==2 (train seems able to be fired again in both cases)
+If spawnflags & TRAIN_RETURN 'Return', seems the train can be returned specifically to one of its path_corners and not just the next one thanks to its netname being the pc's targetname
+
 Animation
 ---------
 Train must have a weaponmodel + the following special settings at each path_corner meant to be reached with an animation:

--- a/hc/spider.hc
+++ b/hc/spider.hc
@@ -368,12 +368,19 @@ void SpiderDie(void) [++ $sdeath1..$sdeath20]
 			self.movetype=MOVETYPE_BOUNCE;
 	}
 
+	/*
 	if(self.frame == $sdeath20)
 	{
 		self.think=SpiderGone;
 	}
 	if(self.health<-20)
 		chunk_death();
+	*/
+	//Inky 20220109 Changed the code above into the one below. Otherwise a runaway loop was susceptible to occur.
+	if(self.health<-20)
+		chunk_death();
+	else if(self.frame == $sdeath20)
+		self.think=SpiderGone;
 }
 
 void SpiderGone(void)

--- a/hc/subs.hc
+++ b/hc/subs.hc
@@ -554,7 +554,7 @@ string s;
 // fire targets
 //
 	self.style=0;
-	if (self.target)
+	if (self.target && self.target != "")
 	{
 		act = activator;
 		t = world;

--- a/hc/triggers.hc
+++ b/hc/triggers.hc
@@ -1226,11 +1226,11 @@ entity SelectSafePoint ()
 	float best_distance = 32000;
 	float distance;
 	entity found = world;
-	entity e;
+	entity e = world;
     
     while( (e = find(e, classname, "info_teleport_destination")) )
     {
-		if(!e.flags) continue;
+		if(e.flags==FALSE) continue;
 		
 		distance = vlen(e.origin - player.origin);
 		if (distance > best_distance) continue;
@@ -1356,7 +1356,7 @@ float poof_speed;
 		}
 	}
 	
-	if((self.netname == "teleportcoin" || t.spawnflags&4) && other==player) //Inky 20201217 Force facing angle at destination
+	if((self.netname == "teleportcoin" || t.spawnflags&4/*Force facing angle*/) && other==player) //Inky 20201217 Force facing angle at destination
 	{
 		vector face = t.mangle;
 		if(face=='0 0 0') face = t.angles;

--- a/hc/triggers_nk.hc
+++ b/hc/triggers_nk.hc
@@ -200,20 +200,16 @@ void trigger_wanderlust_use ()
 		targ = world;
 		do
 		{
-			if(self.target)
-				targ = find (targ, targetname, self.target); //All the occurrences whose targetname is self.target
-			else if(self.netname)
-				targ = find (targ, netname, self.netname); //All the occurrences whose netname is self.netname
-			else if(self.model)
-				targ = find (targ, classname, self.model); //All the occurrences of the class whose name is self.model
+			if(self.spawnflags & 1/*Target netname*/)
+				targ = find (targ, netname, self.target); //All the occurrences whose netname is self.netname
+			else if(self.spawnflags & 2/*Target classname*/)
+				targ = find (targ, classname, self.target); //All the occurrences of the class whose name is self.model
 			else
-			{
-				bprint("trigger_wanderlust doesn't know what to look for.\n");
-				return;
-			}
+				targ = find (targ, targetname, self.target); //All the occurrences whose targetname is self.target
+
 			if (!targ)
 				return;
-			
+
 			if(targ.movechain.classname!="wanderlust")
 			{
 				//Create a wanderlust entity (destination) for the target entity (unless there is one already)
@@ -233,6 +229,11 @@ void trigger_wanderlust_use ()
 			}
 		}
 		while (1);
+	}
+	else
+	{
+		bprint("trigger_wanderlust doesn't know what to look for.\n");
+		return;
 	}
 }
 
@@ -636,6 +637,11 @@ void trigger_setproperty_use ()
 			{
 				referenced = find (world, targetname, self.msg3);bprint("Setting ");bprint(targ.targetname);bprint(".movechain to ");bprint(referenced.classname);bprint(".");bprint(referenced.targetname);bprint("\n");
 				targ.movechain = referenced;
+			}
+			//netname
+			else if (self.netname == "netname")
+			{
+				targ.netname = self.msg3;
 			}
 			//nextthink
 			else if (self.netname == "nextthink")

--- a/hc/wok.fgd
+++ b/hc/wok.fgd
@@ -1,0 +1,3528 @@
+
+//
+// Hexen 2 game definition file (.fgd)
+// For Worldcraft 1.6 and above
+// Updated March 17 1998 (By autolycus)
+// Updated May 17 2012 (By Amran. Fixed errors, added/corrected entities, and revised original)
+// Updated July 30 2013 (By Amran. Added in-editor model support)
+// Updated August 14 2014 (By Amran. Added Wait and delay keys to lights)
+//
+// Written by autolycus
+// Revised by Amran
+//
+
+//
+// worldspawn!
+//
+
+@SolidClass = worldspawn : "World entity"
+[
+	message(string) : "Level name"
+	worldtype(choices) : "World Type" : 0 =
+	[
+		0 : "Castle"
+		1 : "Egypt"
+		2 : "Meso"
+		3 : "Roman"
+	]
+	CD(integer) : "CD track to play" : 1
+	MIDI(string) : "Midi file to play" : "casa1"
+	spawnflags2(choices) : "Func_Train type" : 0 = //Spawnflags don't show for worldspawn. Needs to be edited in the .map manually in order to have mission pack func_trains work properly. (Change 'spawnflags2' to just 'spawnflags')
+	[
+		0 : "Hexen2 Func_Trains"
+		1 : "PoP Func_Trains"
+	]
+	netname(string) : "Netname (PoP)"
+	//Inky:added spawnflags (supported but was missing here)
+	spawnflags(Flags) =
+	[
+		1 : "Mission pack" : 1
+	]
+]
+
+//
+// Base definitions!
+//
+
+@baseclass = Appearflags [
+	spawnflags(Flags) =
+	[
+		256 : "Not for Paladin" : 0
+		512 : "Not for Crusader" : 0
+		1024 : "Not for Necromancer/Succubus" : 0
+		2048 : "Not for Assassin" : 0
+		4096 : "Not in Easy" : 0
+		8192 : "Not in Normal" : 0
+		16384 : "Not in Hard" : 0
+		32768 : "Not in Deathmatch" : 0
+		131072 : "Not in singleplayer" : 0
+	]
+]
+
+@baseclass = Targetname [ targetname(target_source) : "Name" ]
+//@baseclass = Target [ target(target_destination) : "Target" ] //Inky 20201105 Added msg3 & skin
+@baseclass = Target [
+	msg3(string) : "Statement to stuffcmd"
+	skin(integer) : "Set to 1 to print its message to the player even if they're not the activator"
+	target(target_destination) : "Target"
+]
+
+//Inky 20201126
+@baseclass = KillTarget [
+	killtarget(target_destination) : "Set targeted entity's dmg_take to 1 to have it use its th_die function"
+]
+
+@baseclass = Angles [
+	//angles_x(integer) : "Angles X"
+	//angles_Y(integer) : "Angles Y"
+	//angles_Z(integer) : "Angles Z"
+	angles(string) : "Angles (X Y Z)" : "0 0 0"
+]
+
+@baseclass = Spawn [
+	bluemana(integer) : "Blue mana"
+	greenmana(integer) : "Green mana"
+	cnt_torch(integer) : "Torch"
+	cnt_h_boost(integer) : "Quartz flask"
+	cnt_sh_boost(integer) : "Mystic urn"
+	cnt_mana_boost(integer) : "Krater of might"
+	cnt_teleport(integer) : "Chaos device"
+	cnt_tome(integer) : "Tome of power"
+	cnt_summon(integer) : "Stone of summoning"
+	cnt_white(integer) : "White servant" //Inky
+	cnt_invisibility(integer) : "Invisibility"
+	cnt_glyph(integer) : "Glyph of ancients"
+	cnt_haste(integer) : "Boots of speed"
+	cnt_blast(integer) : "Disc of repulsion"
+	cnt_polymorph(integer) : "Ovinimancer"
+	cnt_cubeofforce(integer) : "Force cube"
+	cnt_invincibility(integer) : "Invincibility"
+]
+
+//
+// Entities!
+//
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) color(0 0 255)= air_bubbles : "Air bubbles (PoP)" [
+	cnt(integer) : "Number of Bubbles" : 1
+	wait(integer) : "Wait Style (-2 for burst)" : 0
+]
+
+//
+// Artifacts!
+//
+
+@BaseClass base(Appearflags, Targetname, Target) size(-8 -8 -44, 8 8 20) = Artifact
+[
+	spawnflags(Flags) =
+	[
+		1 : "Floating" : 0
+	]
+	message(string) : "Message"
+	style(integer) : "Light Style"
+]
+@PointClass base(Artifact) studio("models/a_blast.mdl") = art_blastradius : "Blast Radius" []
+@PointClass base(Artifact) studio("models/a_cube.mdl") = art_cubeofforce : "Cube of Force" []
+@PointClass base(Artifact) studio("models/a_glyph.mdl") = art_glyph : "Glyph" []
+//@PointClass base(Artifact) studio("models/a_haste.mdl") = art_haste : "Haste" []           Jocelyhn: hidden by the new White Servant artefact
+@PointClass base(Artifact) studio("models/a_servant.mdl") = art_white : "White Servant" [] //Inky
+@PointClass base(Artifact) studio("models/a_hboost.mdl") = art_HealthBoost : "Health Boost" []
+@PointClass base(Artifact) studio("models/a_invinc.mdl") = art_invincibility : "Invincibility" []
+@PointClass base(Artifact) studio("models/a_invis.mdl") = art_invisibility : "Invisibility" []
+@PointClass base(Artifact) studio("models/a_mboost.mdl") = art_manaboost : "Mana Boost" []
+@PointClass base(Artifact) studio("models/a_poly.mdl") = art_polymorph : "Polymorph" []
+@PointClass base(Artifact) studio("models/a_summon.mdl") = art_summon : "Summoning" []
+@PointClass base(Artifact) studio("models/a_shbost.mdl") = art_SuperHBoost : "Super Health Boost" []
+@PointClass base(Artifact) studio("models/a_telprt.mdl") = art_teleport : "Teleport" []
+@PointClass base(Artifact) studio("models/a_tome.mdl") = art_tomeofpower : "Tome of Power" []
+@PointClass base(Artifact) studio("models/a_torch.mdl") = art_torch : "Torch" []
+
+//
+// Entities!
+//
+
+@PointClass base(Appearflags, Targetname) = buddha_trigger_endgame  : "Buddha trigger endgame (PoP)" []
+
+@SolidClass base(Appearflags, Targetname, Target, Killtarget) = breakable_brush : "Breakable brush"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Kill All" : 0
+		2 : "Hierarchy" : 0
+		4 : "No Link" : 0
+		8 : "Check Name" : 0
+		16 : "Ordered" : 0
+		32 : "Translucent" : 0
+		64 : "Invincible" : 0
+		128 : "Invisible" : 0
+	]
+	flags(integer) : "Hierachial order"
+	strength(integer) : "Recoil distance"
+	thingtype(choices) : "Material type" : 0 =
+	[
+		0 : "Glass"
+		1 : "Grey stone"
+		2 : "Wood"
+		3 : "Metal"
+		4 : "Flesh"
+		5 : "Fire"
+		6 : "Clay"
+		7 : "Leaves"
+		8 : "Hay"
+		9 : "Brown stone"
+		10 : "Cloth (skin 0 red;1 bear;2 red rug;3 blue rug;4 green rug)"
+		11 : "Wood & leaf"
+		12 : "Wood & metal"
+		13 : "Wood & stone"
+		14 : "Metal & stone"
+		15 : "Metal & cloth"
+		16 : "Spider web"
+		//17 : "Glass"
+		18 : "Ice"
+		19 : "Clear glass"
+		20 : "Red glass"
+	]
+	health(choices) : "Health" : 0 =
+	[
+		0 : "Based on material"
+	]
+	abslight(integer) : "Absolute light level"
+]
+
+@SolidClass base(Appearflags, Targetname) = brush_pushable : "Pushable brush"
+[
+	mass(integer) : "Mass" : 5
+	thingtype(choices) : "Material type" : 1 =
+	[
+		0 : "No sound"
+		1 : "Stone/ceramic"
+		2 : "Wood"
+		//4 : "Metal" //Listed on Eye of Horus, doesn't work though?
+	]
+]
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) color(64 64 64) = camera_remote : "Camera"
+[
+	target(target_destination) : "Target (target_null)"
+	wait(integer) : "Time in camera mode" : 3
+	angles_x(integer) : "Pitch (optional)"
+	angles_y(integer) : "Yaw (optional)"
+	netname(string) : "Netname (PoP)"
+	mangle(string) : "Mangle (x y z): if set, the player is made invisible during the cutscene + their facing angle is set to this value upon return" //Inky 20201110
+	nexttarget(target_destination) : "If set, the player is made invisible during the cutscene + their facing angle is set towards this target upon return" //Inky 20201110
+	oldorigin(string) : "If set, 'x y z' position to teleport the player at upon return" //Inky 20201205
+	close_target(target_destination) : "If set, the matching targets will be fired at the end of the cutscene, just before returning to normal view" //Inky 20201210
+	spawnflags(Flags) =
+	[
+		1 : "Can be triggered by a non player" : 0
+		2 : "Solid not" : 0
+		4 : "No enter sound" : 0
+		8 : "No exit sound" : 0
+		16 : "Hide player" : 0
+	]
+	scale(integer) : "FOV value" : 0
+]
+
+//
+// Func Entities!
+//
+
+@SolidClass base(Appearflags, Targetname, Target) = func_angletrigger : "Angle trigger"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Reverse" : 0
+		2 : "X axis" : 0
+		4 : "Y axis" : 0
+	]
+	mangle(string) : "Mangle (x y z)"
+	cnt(integer) : "Degrees per move"
+	speed(integer) : "Speed" : 40
+	dmg(integer) : "Damage when blocked"
+	netname(string) : "Netname"
+	abslight(integer) : "Absolute light level"
+]
+
+@BaseClass base(Appearflags, Targetname, Target) = Button [
+	spawnflags(Flags) =
+	[
+		1 : "Deactivated" : 0
+		2 : "Fired only" : 0
+		4 : "Fire multiple" : 0
+		8 : "Toggle" : 0
+		16: "Facing angle" : 0 //Inky 20201104 Button will fire only if player faces it
+	]
+	speed(integer) : "Speed" : 40
+	wait(choices) : "Wait" : 1 =
+	[
+		-1 : "Stay pressed"
+	]
+	message(string) : "Message"
+	delay(integer) : "Delay"
+	lip(integer) : "Lip" : 4
+	health(integer) : "Health"
+	soundtype(choices) : "Sounds" : 0 =
+	[
+		0 : "Steam metal"
+		1 : "Wooden clunk"
+		2 : "Metallic click"
+		3 : "In-out"
+		//Inky 20201103
+		4 : "Hexen bull chain"
+		5 : "Hexen pebble switch"
+	]
+	netname(string) : "Netname"
+	abslight(integer) : "Absolute light value"
+]
+
+@SolidClass base(Button, ThingType) = func_button : "Button"
+[
+	msg2(string) : "Deactivated Message"
+	aflag(integer) : "Order"
+	angle(integer) : "Angle" : 0 //Inky: natively supported but was missing here
+]
+
+@SolidClass base(Appearflags, Targetname) = func_crusher : "Crusher"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Multiple" : 0
+		2 : "Slide" : 0
+		4 : "Start open" : 0
+		8 : "End open" : 0
+	]
+	speed(integer) : "Speed" : 150
+	dmg(integer) : "Damage" : 10
+	lip(integer) : "Lip" : 4
+	wait(integer) : "Wait" : 1
+	soundtype(choices) : "Sounds" : 1 =
+	[
+		1 : "Base fast"
+		2 : "Chain slow"
+		3 : "Guillotine"
+	]
+]
+
+@BaseClass base(Appearflags, Targetname, Target) = Door
+[
+	spawnflags(Flags) =
+	[
+		1 : "Start open" : 0
+		2 : "Reverse" : 0
+		4 : "Don't link" : 0
+		65536 : "Don't change frame" : 0
+		262144 : "Openable by monsters" : 0
+	]
+	message(string) : "Message"
+	health(integer) : "Health (shootable)"
+	speed(integer) : "Speed" : 100
+	wait(choices) : "Wait" : 3 =
+	[
+		3 : "Default (3)"
+		-1 : "Never return"
+	]
+	dmg(choices) : "Damage" : 2 =
+	[
+		2 : "Default (2)"
+		666 : "Instant kill (666)"
+	]
+	//strength(integer) : "Strength" : 1 //What is this key for?
+	soundtype(choices) : "Sounds" : 2 =
+	[
+		0 : "No sound"
+		1 : "Big metal door, swinging"
+		2 : "Big stone door, sliding"
+		3 : "Big wood door, swinging"
+		4 : "Normal wood door, swinging"
+		5 : "Big wood door, sliding"
+		6 : "Drawbridge"
+		7 : "Rotating walkway"
+		8 : "Big metal door, sliding"
+		9 : "Pendulum swinging"
+		10: "Pen door (light swinging wood)"
+	]
+	noise1(string) : "Stop sound"
+	noise2(string) : "Move sound"
+	noise4(string) : "Start sound"
+]
+
+@SolidClass base(Door) = func_door : "Door"
+[
+	angle(integer) : "Angle" : -1 //Inky: 20191228 Love upward doors, a pain in the ass to make them manually each time!
+	spawnflags(Flags) =
+	[
+		8 : "Toggle" : 0
+		16 : "Slide" : 0
+		32 : "Normal move" : 0
+		64 : "Remove puzzle" : 0
+		128 : "No puzzle" : 0
+	]
+	level(integer) : "Movement length"
+	lip(integer) : "Lip" : 8
+	//v_angle(string) : "Angle to turn" : "0 0 0" //What is this key for?
+	//anglespeed(integer) : "Turning speed" : 0 //What is this key for?
+	puzzle_piece_1(integer) : "Puzzle Piece 1"
+	puzzle_piece_2(integer) : "Puzzle Piece 2"
+	puzzle_piece_3(integer) : "Puzzle Piece 3"
+	puzzle_piece_4(integer) : "Puzzle Piece 4"
+	no_puzzle_msg(string) : "Puzzle message"
+	close_target(string) : "Close Target (PoP)"
+	abslight(integer) : "Absolute light value"
+]
+
+@SolidClass base(Door) = func_door_rotating : "Rotating door"
+[
+	spawnflags(Flags) =
+	[
+		8 : "Remove puzzle" : 0
+		16 : "No puzzle" : 0
+		32 : "Toggle" : 0
+		64 : "X axis" : 0
+		128 : "Y axis" : 0
+	]
+	flags(integer) : "Degrees of rotation"
+	flags2(integer) : "Damage when touched"
+	puzzle_piece_1(integer) : "Puzzle Piece 1"
+	puzzle_piece_2(integer) : "Puzzle Piece 2"
+	puzzle_piece_3(integer) : "Puzzle Piece 3"
+	puzzle_piece_4(integer) : "Puzzle Piece 4"
+	no_puzzle_msg(string) : "Puzzle message"
+	close_target(string) : "Close Target (PoP)"
+	abslight(integer) : "Absolute light value"
+]
+
+//Inky: added base ThingType to have a cool effect like in Quake when hurt
+@SolidClass base(Door, ThingType) = func_door_secret : "Secret door"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Open once" : 0
+		2 : "Move left first" : 0
+		4 : "Move down first" : 0
+		8 : "No shoot" : 0
+		16 : "Always shoot" : 0
+		//32 : "" : 0
+		64 : "Remove puzzle" : 0
+		128: "No puzzle" : 0
+	]
+	lip(integer) : "Lip for final position"
+	frags(integer) : "Lip for first move"
+	t_width(integer) : "Override width"
+	t_length(integer) : "Override length"
+	inactive(integer) : "Deactivated" : 0 //Inky: natively supported but was missing here
+]
+
+@SolidClass base(Appearflags) = func_illusionary : "Illusionary brush"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Translucent" : 0
+		2 : "Light" : 0
+	]
+	abslight(integer) : "Absolute light value"
+]
+
+@PointClass base(Appearflags, Targetname) size(-16 -16 0, 16 16 56) color(255 64 64)= func_monsterspawner : "spawner"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Imp" : 0
+		2 : "Archer" : 0
+		4 : "Wizard" : 0
+		8 : "Scorpian" : 0
+		16 : "Spider" : 0
+		32 : "On death" : 0
+		64 : "Quiet" : 0
+		128 : "Trigger only" : 0
+		65536 : "Big teleport effect" : 0
+		//131072 Don't use. Means the entity won't show in singleplayer
+		262144 : "Angry at player" : 0
+	]
+	cnt(integer) : "Number of spawns" : 17
+	spawnername(string) : "Spawner name"
+        wait(integer) : "Time between spawns (0.5)" : 0
+]
+
+@PointClass base(Appearflags, Targetname) size(-16 -16 0, 16 16 56) color(255 64 64)= func_monsterspawner_mp : "spawner (PoP)"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Ice archer" : 0
+		2 : "Ice imp" : 0
+		4 : "Snow leopard" : 0
+		8 : "Weretiger" : 0
+		16 : "Yakman" : 0
+		32 : "On death" : 0
+		64 : "Quiet" : 0
+		128 : "Trigger only" : 0
+		65536 : "Big teleport effect" : 0
+	]
+	cnt(integer) : "Number of spawns" : 17
+	spawnername(string) : "Spawner name"
+        wait(integer) : "Time between spawns (0.5)" : 0
+]
+
+@PointClass base(Appearflags, Targetname) size(-16 -16 0, 16 16 56) = func_monsterspawn_spot : "spawn spot"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Imp" : 0
+		2 : "Archer" : 0
+		4 : "Wizard" : 0
+		8 : "Scorpian" : 0
+		16 : "Spider" : 0
+		32 : "On death" : 0
+		64 : "Quiet" : 0
+		128 : "Trigger only" : 0
+	]
+	//cnt(integer) : "Number of spawns" : 17 //cnt should be filled out on monsterspawner, not the spot. (Crashes if it reaches the limit)
+	spawnername(string) : "Spawner name"
+        wait(integer) : "Time between spawns (0.5)" : 0
+	aflag(integer) : "Spawn order"
+	dflags(choices) : "Wait when failed" : 0 = //"If dflags is set to "1", the spawner will wait it's "wait" value every time it fails to spawn a monster."
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+]
+
+@PointClass base(Appearflags, Targetname) size(-16 -16 0, 16 16 56) = func_monsterspawn_spot_mp : "spawn spot (PoP)"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Ice archer" : 0
+		2 : "Ice imp" : 0
+		4 : "Snow leopard" : 0
+		8 : "Weretiger" : 0
+		16 : "Yakman" : 0
+		32 : "On death" : 0
+		64 : "Quiet" : 0
+		128 : "Trigger only" : 0
+	]
+	//cnt(integer) : "Number of spawns" : 17 //cnt should be filled out on monsterspawner, not the spot. (Crashes if it reaches the limit)
+	spawnername(string) : "Spawner name"
+        wait(integer) : "Time between spawns (0.5)" : 0
+	aflag(integer) : "Spawn order"
+	dflags(choices) : "Wait when failed" : 0 = //"If dflags is set to "1", the spawner will wait it's "wait" value every time it fails to spawn a monster."
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+]
+
+@SolidClass base(Appearflags, Targetname) = func_newplat : "New plat"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Bottom start" : 0
+		2 : "Return to start" : 0
+		4 : "Continuous" : 0
+		8 : "Triggered at center" : 0
+		16 : "Trigger static" : 0
+	]
+	speed(integer) : "Speed" : 150
+	height(integer) : "Height"
+	soundtype(choices) : "Sounds" : 1 =
+	[
+		1 : "Pully"
+		2 : "Chain"
+	]
+	dmg(integer) : "Damage" : 0
+	wait(integer) : "Wait" : 3
+]
+
+@SolidClass base(Appearflags, Targetname) = func_plat : "Plat"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Trigger low" : 0
+		2 : "Toggle" : 0 //Inky 20201005
+	]
+	speed(integer) : "Speed" : 150
+	height(integer) : "Height"
+	soundtype(choices) : "Sounds" : 1 =
+	[
+		1 : "Pully"
+		2 : "Chain"
+	]
+	dmg(integer) : "Damage" : 0
+	wait(integer) : "Wait" : 3
+]
+
+@SolidClass base(Button) = func_pressure : "Pressure plate"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Activate" : 0
+		2 : "" : 0
+		4 : "" : 0
+	]
+	mass(integer) : "Mass required"
+]
+
+@SolidClass base(Appearflags, Targetname) = func_rotating : "Rotating object"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Start on" : 0
+		2 : "Reverse" : 0
+		4 : "X axis" : 0
+		8 : "Y axis" : 0
+		16 : "Breakable" : 0
+		32 : "Gradual" : 0
+		64 : "Toggle reverse" : 0
+		128 : "Keep start" : 0
+	]
+	speed(integer) : "Speed" : 100
+	dmg(integer) : "Damage when blocked" : 2
+	lifetime(choices) : "Lifetime" : 0 =
+	[
+		0 : "Continuous"
+	]
+	wait(integer) : "Time between lifetimes" : 3
+	thingtype(choices) : "Material type" : 2 =
+	[
+		0 : "Glass"
+		1 : "Grey stone"
+		2 : "Wood"
+		3 : "Metal"
+		4 : "Flesh"
+		5 : "Fire"
+		6 : "Clay"
+		7 : "Leaves"
+		8 : "Hay"
+		9 : "Brown stone"
+		10 : "Cloth"
+		11 : "Wood & leaf"
+		12 : "Wood & metal"
+		13 : "Wood & stone"
+		14 : "Metal & stone"
+		15 : "Metal & cloth"
+		16 : "Spider web"
+		//17 : "Glass"
+		18 : "Ice"
+		19 : "Clear glass"
+		20 : "Red glass"
+	]
+	health(choices) : "Health" : 0 = 
+	[
+		0 : "Based on material"
+	]
+	anglespeed(integer) : "Accel/decell time" : 10
+	abslight(integer) : "Absolute light value"
+]
+
+@SolidClass base(Appearflags, Targetname) = func_rotating_movechain : "Move chain" //Is supposed to link rotating ents to moving ents. Untested
+[
+	spawnflags(Flags) =
+	[
+		1 : "No angle chain" : 0
+	]
+	dmg(integer) : "Damage on touch" 
+	noise(string) : "Noise"
+	noise1(string) : "Impact noise"
+	wait(integer) : "Length of sound (for looping)"
+	avelocity(string) : "Pitch/Yaw/Roll" : "0 0 0"
+	netname(string) : "Netname"
+	abslight(integer) : "Absolute light value"
+]
+
+@SolidClass base(Appearflags, Targetname, Target) = func_train : "Train"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Glow" : 0
+		2 : "Toggle" : 0
+		4 : "Return" : 0
+		8 : "Translucent" : 0
+	]
+	speed(integer) : "Speed" : 100
+	dmg(integer) : "Damage when blocked" : 2
+        soundtype(choices) : "Sound" : 1 =
+	[
+		0 : "No sound"
+		1 : "Ratchet metal"
+	]
+	anglespeed(integer) : "Speed of rotation" : 100
+        wait(choices) : "Wait between moves" : 0 =
+	[
+		0 : "No wait"
+		-1 : "Stop"
+		-2 : "Explode"
+	]
+	pausetime(integer) : "Pause before explode"
+	thingtype(choices) : "Material" : 1 =
+	[
+		0 : "Glass"
+		1 : "Grey stone"
+		2 : "Wood"
+		3 : "Metal"
+		4 : "Flesh"
+		5 : "Fire"
+		6 : "Clay"
+		7 : "Leaves"
+		8 : "Hay"
+		9 : "Brown stone"
+		10 : "Cloth"
+		11 : "Wood & leaf"
+		12 : "Wood & metal"
+		13 : "Wood & stone"
+		14 : "Metal & stone"
+		15 : "Metal & cloth"
+		16 : "Spider web"
+		//17 : "Glass"
+		18 : "Ice"
+		19 : "Clear glass"
+		20 : "Red glass"
+	]
+	abslight(integer) : "Absolute light value"
+]
+
+@SolidClass base(Appearflags, Targetname, Target) = func_train_mp : "Train (PoP)"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Invisible" : 0
+		2 : "Toggle" : 0
+		4 : "Return" : 0
+		8 : "Translucent" : 0
+		16 : "Slope" : 0
+		32 : "Angle match" : 0
+		64 : "Use origin" : 0
+		128 : "Angle wait" : 0
+		65536 : "Model+Brush" : 0
+		//131072 Don't use. Means the entity won't show in singleplayer
+		262144 : "Player model" : 0 //Inky 20201109
+	]
+	speed(integer) : "Speed" : 100
+	dmg(integer) : "Damage when blocked" : 2
+    soundtype(choices) : "Sound" : 1 =
+	[
+		0 : "No sound"
+		1 : "Ratchet metal"
+		2 : "Pullies"
+		3 : "Sliding"
+		4 : "Machine"
+		5 : "Gears"
+		6 : "Guillotine"
+		7 : "Chain"
+		8 : "Rolling boulder"
+		9 : "Prayer wheel"
+		10 : "Secret door" //Inky: 20200307
+	]
+	level(choices) : "Sound falloff" : 0 =
+	[
+		0 : "Normal (ATTN_NORM)"
+		1 : "No falloff (ATTN_NONE)"
+		//Inky 20210821 More options...
+		2 : "ATTN_IDLE"
+		3 : "ATTN_STATIC"
+		4 : "ATTN_LOOP"
+	]
+	weaponmodel(string) : "Model path" //EG:'models/sword.mdl'. Train needs both an origin brush and regular brush to work.
+	angles(string) : "Angles (x y z)"
+	health(integer) : "Health"
+	anglespeed(integer) : "Speed of rotation" : 100
+        wait(choices) : "Wait between moves" : 0 =
+	[
+		0 : "No wait"
+		-1 : "Stop"
+		-2 : "Explode"
+		-3 : "Wait at next corner"
+	]
+	pausetime(integer) : "Pause before explode"
+	thingtype(choices) : "Material" : 1 =
+	[
+		0 : "Glass"
+		1 : "Grey stone"
+		2 : "Wood"
+		3 : "Metal"
+		4 : "Flesh"
+		5 : "Fire"
+		6 : "Clay"
+		7 : "Leaves"
+		8 : "Hay"
+		9 : "Brown stone"
+		10 : "Cloth"
+		11 : "Wood & leaf"
+		12 : "Wood & metal"
+		13 : "Wood & stone"
+		14 : "Metal & stone"
+		15 : "Metal & cloth"
+		16 : "Spider web"
+		//17 : "Glass"
+		18 : "Ice"
+		19 : "Clear glass"
+		20 : "Red glass"
+	]
+	abslight(integer) : "Absolute light value"
+	pos_ofs(string) : "Weapon model offset relatively to origin (x y z)"
+	watertype(choices) : "Liquid content" : 0 =
+	[
+		0 : "Not liquid"
+		-3 : "Water"
+		-4 : "Slime"
+		-5 : "Lava"
+	]
+]
+
+@SolidClass base(Appearflags, Targetname) = func_wall : "Wall"
+[
+        spawnflags(Flags) =
+	[
+		1 : "Translucent" : 0
+		2 : "Invisible" : 0		//Inky: 20191116 native
+		4 : "Toggle" : 0		//Inky: 20191116 Finger of Buddha
+		8 : "Illusionary" : 0	//Inky: 20191116 Finger of Buddha
+	]
+	abslight(integer) : "Absolute light value"
+]
+
+//
+// FX Entities!
+//
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) = fx_colorbeam_end : "End of beam" []
+@PointClass base(Appearflags, Targetname, Target) size(-8 -8 -8, 8 8 8) = fx_colorbeam_start : "Start of beam"
+[
+        spawnflags(Flags) =
+	[
+		1 : "start off" : 0
+	]
+	noise(choices) : "Noise" : 1 =
+	[
+		1 : "No sound (default)"
+		2 : "Lightning"
+	]
+	wait(choices) : "Wait" : -1 =
+	[
+		-1 : "Triggerable"
+	]
+	color(choices) : "Color" : 0 =
+	[
+		0 : "Red"
+		1 : "Blue"
+		2 : "Green"
+		3 : "White"
+		4 : "Yellow"
+	]
+	lifespan(integer) : "Lifespan"
+]
+
+@SolidClass base(Appearflags, Targetname) = fx_friction_change : "Friction change (PoP)"
+[
+	friction(choices) : "Friction" : 1 =
+	[
+		1 : "Normal (1)"
+		0 : "Slippery (> 0, < 1)"
+		2 : "High (> 1)"
+	]
+]
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) = fx_smoke_generator : "smoker"
+[
+	wait(integer) : "Time between puffs" : 2
+	thingtype(choices) : "Type of smoke" : 0 =
+	[
+		0 : "White puff"
+		1 : "Red"
+		2 : "Green"
+		3 : "Grey"
+	]
+	lifespan(integer) : "Lifespan override"
+]
+
+//
+// Info Entities!
+//
+
+//Inky: 20200219 Commented out because of no use in Hexen II
+//@PointClass base(Appearflags) size(-16 -16 -16, 16 16 16) = info_intermission : "intermission camera"
+//[
+//	mangle(string) : "Pitch/Roll/Yaw" : "0 0 0"
+//]
+
+@PointClass base(Appearflags, Targetname) size(-4 -4 -4, 4 4 4) = info_null : "null target"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Don't remove" : 0
+	]
+]
+
+@baseclass base(Appearflags, Targetname) size(-16 -16 0, 16 16 64) color(0 255 0) = PlayerClass []
+
+@PointClass base(PlayerClass) = info_player_start : "Player 1 start" []
+@PointClass base(PlayerClass) = info_player_start2 : "Player 1 start (PoP)" []
+@PointClass base(PlayerClass) = info_player_coop : "Player cooperative start"
+[
+	target(target_destination) : "Target (PoP)"
+	map(string) : "Map (PoP)"
+	playerclass(integer) : "Player class (PoP)"
+]
+@PointClass base(PlayerClass) = info_player_deathmatch : "Player deathmatch start" []
+@PointClass base(PlayerClass) = info_teleport_destination : "Teleport destination"
+[
+	spawnflags(Flags) =
+	[
+		1 : "No throw" : 0
+		2 : "Kill vlocity (?)" : 0
+		4 : "Force facing angle" : 0
+	]
+	flags(integer) : "Any value > 0 makes it a 'safe point' for the Chaos Device"
+]
+
+//
+// Items!
+//
+
+@BaseClass base(Appearflags, Targetname, Target) size(-8 -8 -20, 8 8 45) = Item
+[
+	spawnflags(Flags) =
+	[
+		1 : "floating" : 0
+	]
+	message(string) : "Message"
+	style(integer) : "Light Style"
+]
+
+@PointClass base(Item) studio("models/i_amulet.mdl") = item_armor_amulet : "Armor amulet" []
+@PointClass base(Item) studio("models/i_bracer.mdl") = item_armor_bracer : "Armor bracer" []
+@PointClass base(Item) studio("models/i_bplate.mdl") = item_armor_breastplate : "Breastplate" []
+@PointClass base(Item) studio("models/i_helmet.mdl") = item_armor_helmet : "Helmet" []
+@PointClass base(Item) studio("models/i_hboost.mdl") = item_health : "10 health" //[]
+//Inky: 20191222 Mega health!
+[
+	spawnflags(Flags) =
+	[
+		2 : "Max health" : 0
+	]
+]
+@PointClass base(Item) studio("models/i_btmana.mdl") = item_mana_both : "Mana"
+[
+	spawnflags(Flags) =
+	[
+		2 : "big (30)" : 0
+	]
+]
+@PointClass base(item_mana_both) studio("models/i_bmana.mdl") = item_mana_blue : "blue mana" []
+@PointClass base(item_mana_both) studio("models/i_gmana.mdl") = item_mana_green : "green mana" []
+
+@PointClass base(Appearflags, Targetname, Spawn) size(-8 -8 -20, 8 8 45) color(212 134 232) = item_spawner : "Item spawner"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Reward" : 0
+		2 : "Once on startup" : 0
+	]
+	speed(choices) : "Attenuation" : 0 =
+	[
+		0 : "ATTN_NONE (heard everywhere)"
+		1 : "ATTN_NORM (fades to zero at 1000 units)"
+		2 : "ATTN_IDLE (fades to zero at 512 units)"
+		3 : "ATTN_STATIC (fades to zero at 341 units)"
+	]
+	target(string): "Target(s) triggered upon pick up of the spawned item"
+]
+
+@SolidClass base(Appearflags, Target, Targetname) = trigger_aim : "Trigger: Aiming a netname target"
+[
+	netname(string): "Trigger/targets' netname must match"
+	ideal_yaw(integer) : "Aim accuracy [0-1]"
+]
+
+//
+// Lights!
+//
+
+@PointClass base(Appearflags, Targetname, Target) size(-8 -8 -8, 8 8 8) iconsprite("hexen2models/entities/ent_light.spr") color(255 255 192)= light : "normal light"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Start low" : 0
+		2 : "Hurt (PoP)" : 0
+	]
+	style(choices) : "Style (32-63 for groups)" : 0 =
+	[
+		0 : "Normal"
+		1 : "Soft flicker"
+		6 : "Faster flicker"
+
+		4 : "Low falloff"
+
+		5 : "Pulse"
+		2 : "Slow pulse in & out"
+		11 : "Quick pulse in & out"
+
+		3 : "Erratic pulse & flicker A"
+		7 : "Erratic pulse & flicker B"
+		8 : "Erratic pulse & flicker C"
+		9 : "Slow blink"
+		10 : "Fluorescent flicker"
+		
+		12 : "Custom style 1"
+		13 : "Custom style 2"
+		14 : "Custom style 3"
+		15 : "Custom style 4"
+		16 : "Custom style 5"
+		17 : "Custom style 6"
+		18 : "Custom style 7"
+		19 : "Custom style 8"
+		20 : "Custom style 9"
+		21 : "Custom style 10"
+		22 : "Custom style 11"
+		23 : "Custom style 12"
+		24 : "Custom style 13"
+		
+		25 : "MLS_FULLBRIGHT"
+		26 : "MLS_POWERMODE"
+		27 : "MLS_TORCH"
+		28 : "MLS_FIREFLICKER"
+		29 : "MLS_CRYSTALGOLEM"
+	]
+	light(integer) : "Brightness" : 300
+	wait(integer) : "Wait (decay rate)"
+	delay(integer) : "Delay (attenuation type)"
+	health(integer) : "Health (shootable)"
+	lightvalue1(integer) : "Lowest light value" : 0
+	lightvalue2(integer) : "Highest light value" : 11
+	fadespeed(integer) : "Fade speed" : 1
+]
+@baseclass = Lightdmg [
+	dmg(integer) : "Damage (PoP)"
+]
+@PointClass base(light, Lightdmg) size(-10 -10 -40, 10 10 40) studio("models/flame1.mdl") = light_flame_large_yellow : "Flame large yellow"[]
+@PointClass base(light, Lightdmg) size(-10 -10 -12, 12 12 18) studio("models/flame2.mdl") = light_flame_small_yellow : "Flame small yellow"[]
+@PointClass base(light, Angles) size(-8 -8 -8, 8 8 8) studio("models/gemlight.mdl") = light_gem : "Gem light" []
+@PointClass base(light) size(-8 -8 -8, 8 8 8) studio("models/cflmtrch.mdl") = light_torch_castle : "Castle torch" []
+@PointClass base(light_torch_castle) studio("models/eflmtrch.mdl") = light_torch_eqypt : "Egyptian torch" []
+@PointClass base(light_torch_castle) studio("models/mflmtrch.mdl") = light_torch_meso : "Meso torch" []
+@PointClass base(light_torch_castle) studio("models/rflmtrch.mdl") = light_torch_rome : "Roman torch" []
+@PointClass base(light, Lightdmg) size(-10 -10 -20, 10 10 20) studio("models/flame.mdl") = light_torch_small_walltorch : "Walltorch"
+[
+	light(integer) : "Brightness" : 200
+]
+
+@PointClass base(light, Lightdmg) size(-16 -16 -52, 16 16 16) studio("models/burnerfl.mdl") = light_burner : "Burner (PoP)" []
+@PointClass base(light) size(-8 -8 -16, 8 8 32) studio("models/candle.mdl") = light_candle : "Candle (PoP)" []
+@PointClass base(Lights) model(":models/candle1.mdl") size(-8 -8 -16, 8 8 32) = light_candle1 : "Candle" //Inky 20201031 Candle from SOC
+[
+	spawnflags(Flags) =
+	[
+		1 : "Start low" : 0
+		2 : "Hurt (PoP)" : 0
+		4 : "" : 0
+		8 : "Force candle model in PoP"
+	]
+]
+@PointClass base(light) size(-8 -8 -40, 8 8 8) studio("models/lantern.mdl") = light_lantern : "Lantern (PoP)" []
+@PointClass base(light, Lightdmg) size(-48 -48 -4, 48 48 224) studio("models/newfire.mdl") = light_newfire : "Newfire (PoP)" []
+@PointClass base(light, Lightdmg) size(-0 -16 -0, 22 16 32) studio("models/palight.mdl") = light_palace_torch : "Palace torch (PoP)" []
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) = light_thunderstorm : "Thunderstorm"
+[
+	light(integer) : "Brightness" : 300
+	wait(integer) : "Wait (1 - 100)" : 33
+	dmg(integer) : "Lightning frequency" : 10
+	lightvalue1(integer) : "Normal light value" : 11
+	frags(integer) : "Lightning area radius" : 1000
+	style(integer) : "Light Style"
+]
+
+//
+// Misc Entities!
+//
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) = misc_fireball : "Lava balls" []
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) color(0 0 255)= misc_fountain : "Fountain"
+[
+	angles(string) : "Angles (x y z)" : "0 0 0"
+	movedir(string) : "Direction (x y z)" : "1 1 1"
+	color(integer) : "Color" : 407
+	cnt(integer) : "Number of particles" : 2
+]
+
+//
+// Monsters!
+//
+
+@BaseClass base(Appearflags, Targetname, Target) size(-16 -16 0, 16 16 50) color(220 0 0) = Monster
+[
+	spawnflags(Flags) =
+	[
+		1 : "Ambush" : 0 //Only wakes up when player is within this enemies line of sight
+		2 : "Stuck" : 0 //Cannot move from original position (only some enemies)
+		4 : "Jump" : 0 //Has the ability to leap forward
+		8 : "Play dead (PoP)" : 0 //Possibly no useful effect?
+		16 : "Dormant (imps only)" : 0 //Possibly no useful effect?
+		32 : "No drop" : 0 //Will not drop random mana or items on death? Or doesn't drop to floor on spawn?
+		64 : "Frozen (PoP)" : 0 //Enemy is made out of ice
+	]
+	health(integer) : "Health (PoP)"
+	experience(integer) : "Experience (PoP)" //Doesn't seem to work
+]
+
+@PointClass base(Monster) studio("models/archer.mdl") = monster_archer : "Archer" []
+@PointClass base(Monster) studio("models/archerlord.mdl") = monster_archer_lord : "Archer lord" []
+
+@PointClass base(Monster) size(-14 -14 -41, 14 14 23) studio("models/fangel.mdl") = monster_fallen_angel : "Fallen angel" []
+@PointClass base(Monster) size(-14 -14 -41, 14 14 23) studio("models/fangellord.mdl") = monster_fallen_angel_lord : "Fallen angel lord" []
+
+@PointClass base(Monster) size(-32 -32 0, 32 32 112) studio("models/golem_s.mdl") = monster_golem_stone : "Stone golem" []
+@PointClass base(Monster) size(-55 -55 0, 55 55 120) studio("models/golem_i.mdl") = monster_golem_iron : "Iron golem" []
+@PointClass base(Monster) size(-64 -64 0, 64 64 194) studio("models/golem_b.mdl") = monster_golem_bronze : "Bronze golem" []
+@PointClass base(Monster) size(-32 -32 -24, 32 32 64) studio("models/golem_s.mdl") = monster_golem_crystal : "Crystal golem" []
+
+@PointClass base(Monster) size(-40 -40 -42, 40 40 42) studio("models/hydra.mdl") = monster_hydra : "Hydra"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Stand" : 0
+		2 : "Hover" : 0
+	]
+]
+
+//@PointClass base(Monster) studio("models/imp.mdl") = monster_imp_fire : "Fire imp"
+@PointClass base(Monster) model({{spawnflags & 16 -> {"path": "models/imp.mdl", "skin": 1, "frame": 78},"models/imp.mdl"}}) = monster_imp_fire : "Fire imp"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Stand" : 0
+		2 : "Hover" : 0
+		4 : "" : 0
+		8 : "" : 0
+		16 : "Gargoyle" : 0
+		32 : "" : 0
+		64 : "" : 0
+	]
+	wait(integer) : "Wait (-1 for decoration)"
+]
+@PointClass base(monster_imp_fire) studio("models/impice.mdl") = monster_imp_ice : "Ice imp" []
+@PointClass base(monster_imp_fire) studio("models/implord.mdl") = monster_imp_lord : "Lord imp" [] //Seems to vanish right away, this is the summon artifact imp
+
+@PointClass base(Monster) studio("models/medusa.mdl") = monster_medusa_green : "Green medusa" []
+@PointClass base(monster_medusa_green) studio("models/medusa.mdl") = monster_medusa_red : "Red medusa" []
+
+@PointClass base(Monster) size(-16 -16 0, 16 16 55) studio("models/mummy.mdl") = monster_mummy : "Mummy" []
+@PointClass base(Monster) studio("models/mummylord.mdl") = monster_mummy_lord : "Mummy lord" []
+
+@PointClass base(Monster) size(-40 -40 0, 40 40 64) studio("models/scorpion.mdl") = monster_scorpion_yellow : "Yellow scorpion (easier)" []
+@PointClass base(monster_scorpion_yellow) studio("models/scorpionblack.mdl") = monster_scorpion_black : "Black scorpion (harder)" []
+
+@PointClass base(Monster) size(-24 -24 0, 24 24 64) studio("models/skullwiz.mdl") = monster_skull_wizard : "Skull wizard" []
+@PointClass base(monster_skull_wizard) studio("models/skullwizlord.mdl") = monster_skull_wizard_lord : "Skull wizard lord" []
+
+@BaseClass base(Monster) = Spider
+[
+	spawnflags(Flags) =
+	[
+		32 : "On wall" : 0
+	]
+]
+@PointClass base(Spider) size(-12 -12 0, 12 12 16) studio("models/spideryellow.mdl") = monster_spider_yellow_small : "Small yellow spider" []
+@PointClass base(Spider) size(-16 -16 0, 16 16 26) studio("models/spideryellow.mdl") = monster_spider_yellow_large : "Big yellow spider" []
+@PointClass base(Spider) size(-12 -12 0, 12 12 16) studio("models/spiderred.mdl") = monster_spider_red_small : "Small red spider" []
+@PointClass base(Spider) size(-16 -16 0, 16 16 26) studio("models/spiderred.mdl") = monster_spider_red_large : "Big red spider" []
+
+@PointClass base(Monster) studio("models/mezzoman.mdl") = monster_werejaguar : "Werejaguar" []
+@PointClass base(monster_werejaguar) studio("models/mezzomanblack.mdl") = monster_werepanther : "Werepanther" []
+
+@PointClass base(Appearflags, Targetname, Target) size(-16 -16 -8, 16 16 8) studio("models/fish.mdl") = monster_fish : "Fish" 
+[
+	skin(choices) : "Skin" : 0 =
+	[
+		0 : "Bright colored"
+		1 : "Darker colored"
+	]
+]
+@PointClass base(Appearflags, Targetname, Target) size(-3 -3 0, 3 3 7) studio("models/rat.mdl") = monster_rat : "Rat"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Ambush" : 0
+	]
+]
+@PointClass base(monster_rat) size(-20 -20 0, 20 20 10) studio("models/rat.mdl") = monster_ratnest : "Rat's nest" []
+@PointClass base(Monster) size(-16 -16 0, 16 16 32) studio("models/raven.mdl") = monster_raven : "Raven" []
+
+@PointClass base(Appearflags, Targetname, Target) size(-80 -80 0, 80 80 200) studio("models/snake.mdl") = monster_snake : "Snake"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Ambush" : 0
+	]
+]
+@PointClass base(Appearflags, Targetname, Target) size(-100 -100 0, 100 100 666) studio("models/smaleido.mdl") = monster_eidolon : "Eidolon" []
+
+//
+// PoP Monsters!
+//
+
+@PointClass base(Monster) studio("models/archer2.mdl") = monster_archer_ice : "Ice archer (PoP)" []
+@PointClass base(Monster) size(-20 -20 0, 20 20 40) studio("models/pent.mdl") = monster_pentacles : "Pentacle (PoP)"
+[
+	skin(choices) : "Skin" : 0 =
+	[
+		0 : "Rocky brown"
+		1 : "Snowy white"
+	]
+]
+@PointClass base(Monster) studio("models/snowtiger.mdl") = monster_weretiger : "Weretiger (PoP)" []
+@PointClass base(Monster) studio("models/snowleopard.mdl") = monster_weresnowleopard : "Wereleopard (PoP)" []
+@PointClass base(Monster) size(-32 -32 0, 32 32 104)
+model
+(
+	{{
+		//Custom skin unsupported in TB (?)
+		(skin > 2) -> {"path": "models/yakman.mdl", "scale": scale },
+		//Vanilla skin
+		{"path": "models/yakman.mdl", "scale": scale, "skin": skin }
+	}}
+) = monster_yakman : "Yak (PoP)"
+[
+	skin(choices) : "Skin" : 0 =
+	[
+		-1 : "White (Greater chance to shoot ice)"
+		1 : "Brown (Even chance)"
+		2 : "Black (Greater chance to charge)"
+		3 : "Shambler"
+		4 : "Shepherd (spotted)"
+	]
+]
+@PointClass base(Appearflags, Targetname, Target) size(-100 -100 0, 100 100 666) studio("models/bigeido.mdl") = monster_eidolon_weakling : "Eidolon weakling (PoP)" []
+@PointClass base(Appearflags, Targetname, Target) size(-8 -8 -8, 8 8 8) studio("models/pravus.mdl") = monster_buddha : "Praevus (PoP)"
+[
+	netname(string) : "Netname"
+]
+
+//
+// Objects!
+//
+
+@PointClass base(Appearflags, Targetname, Target) size(-45 -45 0, 45 45 60) studio("models/ballista.mdl") = obj_ballista : "Ballista"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Track" : 0
+	]
+	health(choices) : "Health" : 0 =
+	[
+		0 : "Indestructible"
+	]
+	cnt(integer) : "Degrees of pitch off start" : 30
+	count(integer) : "Degrees per movement" : 5
+	dmg(integer) : "Damage of projectile" : 50
+	speed(integer) : "Delay between firings" : 5
+	//mass(integer) : "Mass"
+]
+
+@BaseClass base(Appearflags, Targetname, Target, Angles) = Object
+[
+	health(integer) : "Health"
+	scale(integer) : "Scale"
+	mass(integer) : "Mass"
+	message(string) : "Message"
+	abslight(integer) : "Absolute light value"
+]
+
+@BaseClass base(Object) size(-13 -13 0, 13 13 36) = Barrels
+[
+	spawnflags(Flags) =
+	[
+		1 : "Downhill" : 0
+		2 : "No drop" : 0
+		4 : "On side" : 0
+		8 : "Sink" : 0
+	]
+	health(integer) : "Health" : 25
+]
+@PointClass base(Barrels, Spawn) studio("models/barrel.mdl") = obj_barrel : "Barrel" []
+@PointClass base(Barrels, Spawn) studio("models/barrelex.mdl") = obj_barrel_exploding : "Barrel exploding" []
+@PointClass base(Barrels, Spawn) studio("models/barrelst.mdl") = obj_barrel_indestructible : "Barrel indestructible" []
+
+@PointClass base(Object) size(-10 -10 -5, 10 10 32) studio("models/stool.mdl") = obj_barstool : "Bar stool" []
+
+//Inky: obj_beefslab become "pushable" if proper flag set (previous PointClass definition: [])
+@PointClass base(Object) size(-16 -16 0, 16 16 40) studio("models/beefslab.mdl") = obj_beefslab : "Slab o' beef"
+[
+    spawnflags(Flags) =
+	[
+		1 : "Pushable" : 0
+	]
+]
+
+@PointClass base(Object) size(-100 -100 -210, 100 100 8) studio("models/bellring.mdl") = obj_bell : "Bell" []
+@PointClass base(Object) size(-30 -30 0, 30 30 40) studio("models/bench.mdl") = obj_bench : "Bench" []
+@PointClass base(Object) size(-10 -10 0, 10 10 10) studio("models/bonepile.mdl") = obj_bonepile : "Pile o' bones" []
+@PointClass base(Object) size(-8 -8 0, 8 8 10) studio("models/bookclos.mdl") = obj_book_closed : "Closed book" []
+@PointClass base(obj_book_closed) studio("models/bookopen.mdl") = obj_book_open : "Open book" []
+@PointClass base(Object) size(-16 -16 0, 16 16 40) studio("models/bush1.mdl") = obj_bush1 : "Bush" []
+@PointClass base(Object) size(-36 -32 -10, 36 75 64) studio("models/cart.mdl") = obj_cart : "Cart" []
+
+@PointClass base(Object) size(-50 -50 -230, 50 50 8)
+model
+({{
+	spawnflags & 2 ->  {"scale": 0.75, "path": "models/bonsho.mdl"},
+	spawnflags & 4 ->  {"scale": 0.60, "path": "models/bonsho.mdl"},
+	spawnflags & 8 ->  {"scale": 0.30, "path": "models/bonsho.mdl"},
+	spawnflags & 16 -> {"scale": 0.20, "path": "models/bonsho.mdl"},
+	"models/bonsho.mdl"
+}})
+= obj_bonsho : "Buddhist bell"
+[
+    spawnflags(Flags) =
+	[
+		1  : "Sol" : 0
+		2  : "La" : 1
+		4  : "Si" : 0
+		8  : "Do" : 0
+		16 : "Ré" : 0
+	]
+	scale(integer) : "Size" : 1
+]
+
+@PointClass base(Appearflags, Targetname, Target, Angles) size(-160 -160 -0, 160 160 160) studio("models/cattest.mdl") = obj_catapult2 : "Catapult"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Not useable (PoP)" : 0
+	]
+	health(choices) : "Health" : 1000 =
+	[
+		0 : "Indestructible"
+	]
+	wait(integer) : "Delay before reset" : 3
+	speed(integer) : "Launch speed" : 300
+	thingtype(choices) : "Material" : 2 =
+	[
+		0 : "Glass"
+		1 : "Grey stone"
+		2 : "Wood"
+		3 : "Metal"
+		4 : "Flesh"
+		5 : "Fire"
+		6 : "Clay"
+		7 : "Leaves"
+		8 : "Hay"
+		9 : "Brown stone"
+		10 : "Cloth"
+		11 : "Wood & leaf"
+		12 : "Wood & metal"
+		13 : "Wood & stone"
+		14 : "Metal & stone"
+		15 : "Metal & cloth"
+		16 : "Spider web"
+		//17 : "Glass"
+		18 : "Ice"
+		19 : "Clear glass"
+		20 : "Red glass"
+	]
+	//mass(integer) : "Mass"
+	//sounds
+	//soundtype
+]
+
+@PointClass base(Object) size(-16 -16 0, 16 16 40) studio("models/cauldron.mdl") = obj_cauldron : "Cauldron" []
+@PointClass base(Object) size(-10 -10 -5, 10 10 40) studio("models/chair.mdl") = obj_chair : "Chair" []
+@PointClass base(Object) size(-100 -100 0, 100 100 200) studio("models/chaosorb.mdl") = obj_chaos_orb : "Chaos orb" [] //Spawns at 0,0,0 in the world regardless of where it is placed
+
+@PointClass base(Object) size(-16 -16 0, 16 16 32) studio("models/chest1.mdl") = obj_chest1 : "Chest #1"
+[
+	skin(choices) : "Skin" : 0 =
+	[
+		0 : "Generic texture"
+		1 : "Wood texture"
+	]
+	bluemana(integer) : "Blue mana"
+	greenmana(integer) : "Green mana"
+	cnt_torch(integer) : "Torch"
+	cnt_h_boost(integer) : "Quartz flask"
+	cnt_sh_boost(integer) : "Mystic urn"
+	cnt_mana_boost(integer) : "Krater of might"
+	cnt_teleport(integer) : "Chaos device"
+	cnt_tome(integer) : "Tome of power"
+	cnt_summon(integer) : "Stone of summoning"
+	cnt_white(integer) : "White servant" //Inky
+	cnt_invisibility(integer) : "Invisibility"
+	cnt_glyph(integer) : "Glyph of ancients"
+	cnt_haste(integer) : "Boots of speed"
+	cnt_blast(integer) : "Disc of repulsion"
+	cnt_polymorph(integer) : "Ovinimancer"
+	cnt_cubeofforce(integer) : "Force cube"
+	cnt_invincibility(integer) : "Invincibility"
+]
+@PointClass base(Object) size(-16 -16 0, 16 16 32) model({"path": "models/chest2.mdl", "skin": skin}) = obj_chest2 : "Chest #2"
+[
+	skin(choices) : "Skin" : 0 =
+	[
+		0 : "Meso texture"
+		1 : "Egypt texture"
+		2 : "Wood texture"
+		3 : "Tibet texture"
+	]
+	bluemana(integer) : "Blue mana"
+	greenmana(integer) : "Green mana"
+	cnt_torch(integer) : "Torch"
+	cnt_h_boost(integer) : "Quartz flask"
+	cnt_sh_boost(integer) : "Mystic urn"
+	cnt_mana_boost(integer) : "Krater of might"
+	cnt_teleport(integer) : "Chaos device"
+	cnt_tome(integer) : "Tome of power"
+	cnt_summon(integer) : "Stone of summoning"
+	cnt_white(integer) : "White servant" //Inky
+	cnt_invisibility(integer) : "Invisibility"
+	cnt_glyph(integer) : "Glyph of ancients"
+	cnt_haste(integer) : "Boots of speed"
+	cnt_blast(integer) : "Disc of repulsion"
+	cnt_polymorph(integer) : "Ovinimancer"
+	cnt_cubeofforce(integer) : "Force cube"
+	cnt_invincibility(integer) : "Invincibility"
+]
+@PointClass base(Object, Spawn) size(-16 -16 0, 16 16 32) studio("models/chest3.mdl") = obj_chest3 : "Chest #3" []
+
+@PointClass base(Object) size(-32 -32 0, 32 32 10) studio("models/corps1.mdl") = obj_corpse1 : "Corpse #1"
+[
+	skin(choices) : "Skin" : 0 =
+	[
+		0 : "Burnt, nude guy"
+		1 : "Normal, nude guy"
+		2 : "Diseased, nude guy"
+		3 : "Wound, has pants"
+	]
+]
+@PointClass base(obj_corpse1) studio("models/corps2.mdl") = obj_corpse2 : "Corpse #2" 
+[
+	skin(choices) : "Skin" : 0 =
+	[
+		0 : "Shoulder and face wound"
+		1 : "Clawed chest"
+		2 : "Stomach wound"
+		3 : "Just dead"
+		4 : "Webbed"
+	]
+]
+
+@PointClass base(Object) size(-26 -26 0, 26 26 70) studio("models/fence.mdl") = obj_fence : "Fence" []
+@PointClass base(Object) size(-16 -16 0, 16 16 160) model({"path": "models/flag.mdl", "skin":skin}) = obj_flag : "Flag" []
+@PointClass base(Object) size(-24 -24 0, 24 24 80) studio("models/fountain.mdl") = obj_fountain : "Fountain" []
+@PointClass base(Object) size(-16 -16 0, 16 16 80) studio("models/hedge1.mdl") = obj_hedge1 : "X-Mas tree" []
+@PointClass base(obj_hedge1) studio("models/hedge2.mdl") = obj_hedge2 : "Square, medium hedge" []
+@PointClass base(obj_hedge2) studio("models/hedge3.mdl") = obj_hedge3 : "Tall, thin hedge" []
+@SolidClass base(Appearflags) = obj_ice : "Ice"
+[
+	spawnflags(Flags) =
+	[
+		1 : "No transparency" : 0
+	]
+	health(integer) : "Health" : 20
+        friction(integer) : "Friction" : 0
+        abslight(integer) : "Absolute light value"
+]
+@PointClass base(Object) size(-16 -40 0, 16 40 50) studio("models/pew.mdl") = obj_pew : "Pew" []
+@PointClass base(Object) size(-10 -10 0, 10 10 20) studio("models/plantgen.mdl") = obj_plant_generic : "Generic plant" []
+@PointClass base(Object) size(-10 -10 0, 10 10 40) studio("models/plantmez.mdl") = obj_plant_meso : "Meso plant" []
+@PointClass base(Object) size(-24 -24 0, 24 24 90) studio("models/plantrom.mdl") = obj_plant_rome : "Roman plant" []
+@PointClass base(Object) size(-8 -8 0, 8 8 16) studio("models/h_ass.mdl") = obj_playerhead_assassin : "Assassin head" []
+@PointClass base(obj_playerhead_assassin) studio("models/h_cru.mdl") = obj_playerhead_crusader : "Crusader head" []
+@PointClass base(obj_playerhead_assassin) studio("models/h_nec.mdl") = obj_playerhead_necromancer : "Necro head" []
+@PointClass base(obj_playerhead_assassin) studio("models/h_pal.mdl") = obj_playerhead_paladin : "Paladin head" []
+@PointClass base(Object, Spawn) size(-24 -24 0, 24 24 50) studio("models/pot1.mdl") = obj_pot1 : "Pot #1" []
+@PointClass base(obj_pot1) size(-16 -16 0, 16 16 40) studio("models/pot2.mdl") = obj_pot2 : "Pot #2" []
+@PointClass base(obj_pot2) studio("models/pot3.mdl") = obj_pot3 : "Pot #3" []
+@PointClass base(Object) size(-8 -8 0, 8 8 32) studio("models/seaweed.mdl") = obj_seaweed : "Sea weed" []
+@PointClass base(Object) size(-8 -8 0, 8 8 16) studio("models/skull.mdl") = obj_skull : "Skull" []
+@PointClass base(Object) size(-16 -16 0, 16 16 40) studio("models/skllstk1.mdl") = obj_skullstick : "1 skull, stick" []
+@PointClass base(Object) size(-16 -16 0, 16 16 40) studio("models/skllstk2.mdl") = obj_skull_stick2 : "2 skulls, stick" []
+@PointClass base(Object) size(-60 -60 0, 60 60 120) studio("models/anglstat.mdl") = obj_statue_angel : "Angel" []
+@PointClass base(Object) size(-30 -30 0, 30 30 90) studio("models/athena.mdl") = obj_statue_athena : "Athena" []
+@PointClass base(Object) size(-24 -24 0, 24 24 90) studio("models/caesar.mdl") = obj_statue_caesar : "Caesar" []
+@PointClass base(Object) size(-30 -30 0, 30 30 120) studio("models/king.mdl") = obj_statue_king : "King" []
+@PointClass base(Object) size(-56 -14 0, 56 14 60) studio("models/lion.mdl") = obj_statue_lion : "Lion" []
+@PointClass base(Object) size(-30 -30 0, 30 30 80) studio("models/mars.mdl") = obj_statue_mars : "Mars" []
+@PointClass base(Object) size(-16 -16 0, 16 16 160) studio("models/mumstatu.mdl") = obj_statue_mummy : "Mummy" []
+@PointClass base(Object) size(-16 -16 -26, 16 16 160) studio("models/mhdstatu.mdl") = obj_statue_mummy_head : "Mummy head"[]
+@PointClass base(Object) size(-30 -30 0, 30 30 100) studio("models/neptune.mdl") = obj_statue_neptune : "Neptune" []
+@PointClass base(Object) size(-40 -40 0, 40 40 130) studio("models/olmec1.mdl") = obj_statue_olmec : "Olmec???" []
+@PointClass base(Object) size(-16 -16 0, 16 16 80) studio("models/snkstatu.mdl") = obj_statue_snake : "Snake" []
+@PointClass base(Object) size(-44 -44 0, 44 44 90) studio("models/snakecoil.mdl") = obj_statue_snake_coil : "Coiling snake" []
+@PointClass base(Object) size(-36 -36 0, 36 36 248) studio("models/tutstatu.mdl") = obj_statue_tut : "Tut" []
+@PointClass base(Object) size(-16 -16 -8, 16 16 8) studio("models/sword.mdl") = obj_sword : "Sword" []
+@PointClass base(Object) size(-24 -24 0, 24 24 60) studio("models/tombstn1.mdl") = obj_tombstone1 : "Cross tombstone" []
+@PointClass base(Object) size(-16 -16 0, 16 16 40) studio("models/tombstn2.mdl") = obj_tombstone2 : "Rounded tombstone" []
+@PointClass base(Object) size(-42 -42 0, 42 42 160) studio("models/tree.mdl") = obj_tree : "Leaveless tree" []
+@PointClass base(Object) size(-140 -140 -16, 140 140 220) studio("models/tree2.mdl") = obj_tree2 : "Normal tree" []
+@PointClass base(Object) size(-25 -25 -25, 25 25 25) model({"path": "models/webs.mdl", "skin": skin}) = obj_webs : "Spider web"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Solid" : 0
+		2 : "Animate" : 0
+		4 : "Weak" : 0
+		8 : "Touch & move" : 0
+		16 : "Flat" : 0
+		32 : "No transparency" : 0
+	]
+	skin(choices) : "Skin" : 0 =
+	[
+		-1 : "Giant web (15x scale)"
+		0 : "Many little webs"
+		1 : "Corner web"
+		2 : "Cobwebs"
+		3 : "Giant web"
+		4 : "Yurt door" //Inky 20201122 Replaces "Giant web (15x scale)" at slot 4
+	]
+	v_angle(string) : "Angle of web (x y z)" : "0 0 0"
+]
+
+//
+// PoP Objects!
+//
+
+@PointClass base(Object) size(-8 -8 -0, 8 8 8) studio("models/openbook.mdl") = obj_book_o_the_dead : "Book (PoP)" []
+@PointClass base(Object) size(-32 -32 -128, 32 32 0) studio("models/ch-kite.mdl") = obj_chinese_kite_lamp : "Kite lamp (PoP)" []
+@PointClass base(Object) size(-8 -8 -96, 8 8 0) studio("models/ch-hang.mdl") = obj_chinese_sign : "Sign (PoP)" [] //size(-8 -72 -96, 8 72 0)
+@PointClass base(Object) size(-0 -48 -0, 96 48 120) studio("models/demstat.mdl") = obj_demon_statue : "Demon statue (PoP)" []
+@PointClass base(Object) size(-20 -20 -0, 20 20 80) studio("models/samurai.mdl") = obj_samurai : "Samurai statue (PoP)" []
+@PointClass base(Object) size(-16 -16 -0, 16 16 72) studio("models/4arm.mdl") = obj_shiva : "Shiva (PoP)" []
+@PointClass base(Object) size(-12 -12 -0, 12 12 12) studio("models/skeleton.mdl") = obj_skeleton : "Skeleton (PoP)" [] //size(-40 -12 -0, 40 12 12)
+//Inky: 
+//@PointClass base(Object) size(-32 -32 -0, 32 32 120) studio("models/sk-throne.mdl") = obj_skeleton_throne : "Skeleton on throne (PoP)" []
+@PointClass base(Object) size(-32 -32 -0, 32 32 120) studio("models/sk-throne.mdl") = obj_skeleton_throne : "Skeleton on throne (PoP)"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Breakable" : 0
+	]
+]
+@PointClass base(Object) size(-40 -56 -0, 40 56 64) studio("models/snowcrnr.mdl") = obj_snow_corner : "Snow corner (PoP)" []
+@PointClass base(Object) size(-24 -32 -0, 24 32 16) studio("models/snowpile.mdl") = obj_snow_pile : "Snow pile (PoP)" []
+@PointClass base(Object) size(-0 -80 -0, 40 80 40) studio("models/snowwall.mdl") = obj_snow_wall : "Snow wall (PoP)" []
+@PointClass base(Object) size(-32 -32 -16, 32 32 32) studio("models/stlgmt1.mdl") = obj_stalagmite1 : "Stalagmite1 (PoP)" []
+@PointClass base(Object) size(-40 -40 -24, 40 40 24) studio("models/stlgmt2.mdl") = obj_stalagmite2 : "Stalagmite2 (PoP)" [] //Sinks into the ground
+@PointClass base(Object) size(-16 -16 -0, 16 16 64) studio("models/draglion.mdl") = obj_statue_dragon_lion : "Dragon statue (PoP)" [] //size(-40 -16 -0, 40 16 64)
+@PointClass base(Object) size(-8 -8 -64, 8 8 64) studio("models/talkingdoor.mdl") = obj_talking_door : "Talking door (PoP)" []
+
+//
+// Entities!
+//
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) color(192 64 192) = path_corner : "Monster and train path"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Synch" : 0
+		2 : "Continue on next anim" : 0
+		4 : "Anim back & forth" : 0
+	]
+	target(target_destination) : "Next path_corner"
+	angles(string) : "Angles (x y z)"
+	wait(integer) : "Wait (-1 stops, -2 destroys)" : 0
+	speed(integer) : "Speed"
+	anglespeed(integer) : "Rotation speed"
+	//Inky 20201105 For animated trains
+	button0(integer) : "Starting animation frame # within the [button1-button2] range (button1 by default)"
+	button1(integer) : "First animation frame"
+	button2(integer) : "Last animation frame"
+	frags(integer) : "Animation frames duration; default 0.05" : 0.05
+	//Inky 20201109 Triggering automatic player model animation. "Crouch stand" dummy value only there for compatibility with vanilla HexenC animation frames tables
+	modelindex(choices) : "Player model animation (automatically sets button1, button2 & frags)" : 0 =
+	[
+		1 : "Stand"
+		2 : "Run"
+		3 : "Swim"
+		4 : "Attack"
+		5 : "Pain"
+		6 : "Jump"
+		7 : "Crouch stand"
+		8 : "Crouch move"
+		9 : "Dead"
+		10: "Decap"
+	]
+	close_target(target_destination) : "Target(s) fired by the train when reaching this path_corner"
+]
+
+@PointClass base(Monster) size(-8 -8 0, 8 8 32) studio("models/sheep.mdl") = player_sheep : "Sheep"
+[
+	spawnflags(Flags) =
+	[
+		1 : "No not move" : 0
+	]
+]
+
+@SolidClass base(Appearflags, Targetname) = plaque : "Readable plaque"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Invisible" : 0
+		2 : "Deactivated" : 0
+		4 : "No LoS (PoP)" : 0
+		8 : "Not solid (PoP)" : 0
+	]
+	message(integer) : "String index #"
+	//noise1(string) : "Noise (dir/sound.wav)"
+	level(integer) : "Count of possible answers"
+	puzzle_piece_1(string) : "Target for answer #1"
+	puzzle_piece_2(string) : "Target for answer #2"
+	puzzle_piece_3(string) : "Target for answer #3"
+	puzzle_piece_4(string) : "Target for answer #4"
+	target(target_destination) : "Target(s) fired by reading the plaque"
+	killtarget(target_destination) : "Target(s) killed by reading the plaque"
+]
+
+@PointClass base(Appearflags, Targetname, Target) size(-8 -8 -8, 8 8 16) color(80 0 200) model({ "path": "models/puzzle/"+puzzle_id+".mdl" })= puzzle_piece : "Puzzle piece"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Spawn" : 0
+		2 : "Floating" : 0
+		4 : "Auto get" : 0
+		8 : "Reward" : 0
+	]
+	puzzle_id(string) : "Puzzle id (no path/.mdl)"
+	message(string) : "Message"
+	netname(string) : "Puzzle piece name displayed when picked up"
+	speed(choices) : "Reward sound attenuation" : 0 =
+	[
+		0 : "ATTN_NONE (heard everywhere)"
+		1 : "ATTN_NORM (fades to zero at 1000 units)"
+		2 : "ATTN_IDLE (fades to zero at 512 units)"
+		3 : "ATTN_STATIC (fades to zero at 341 units)"
+	]
+	style(integer) : "Light Style"
+]
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) color(80 0 200) model({ "path": "models/puzzle/"+puzzle_id+".mdl" })= puzzle_static_piece : "Static puzzle piece"
+[
+	puzzle_id(string) : "Puzzle id" //Model name also works (without path or .mdl)
+	lifespan(integer) : "Lifespan"
+]
+
+//
+// Rider Stuff!
+//
+
+@PointClass base(Appearflags, Targetname) size(-55 -55 -24, 55 55 100) studio("models/dthhorse.mdl") = rider_death : "Death!"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Trigger wait" : 0
+	]
+	target(string) : "Start spot on next map"
+	map(string) : "Next map after killing"	
+]
+@PointClass base(rider_death) studio("models/famhorse.mdl") = rider_famine : "Famine!" []
+@PointClass base(rider_death) studio("models/boar.mdl") = rider_pestilence : "Pestilence!" []
+@PointClass base(rider_death) size(-50 -50 -24, 50 50 100) studio("models/warhorse.mdl") = rider_war : "War!" []
+
+@PointClass base(Appearflags, Targetname) = rider_path : "Rider path"
+[
+	path_id(string) : "Path id"
+	next_path_1(string) : "Next path 1"
+	next_path_2(string) : "Next path 2"
+	next_path_3(string) : "Next path 3"
+	next_path_4(string) : "Next path 4"
+	next_path_5(string) : "Next path 5"
+	next_path_6(string) : "Next path 6"
+]
+@SolidClass base(Appearflags, Targetname) = rider_quake : "Rider quake"
+[
+	model(string) : "Model"
+	rt_chance(integer) : "Chance of triggering (0-1)"
+	abslight(integer) : "Absolute light value"
+]
+@PointClass base(Appearflags, Targetname) = rider_quake_center : "Rider quake center"
+[
+	rt_chance(integer) : "Chance of triggering (0-1)"
+]
+@SolidClass base(Appearflags, Targetname, Target) = rider_trigger_multiple : "Rider trigger multiple"
+[
+	rt_chance(integer) : "Chance of triggering (0-1)" : 1
+]
+@SolidClass base(rider_trigger_multiple) = rider_trigger_once : "Rider trigger once"
+[
+	model(string) : "Model"
+]
+
+//
+// Rings!
+//
+
+@PointClass base(Item) size(-8 -8 -44, 8 8 20) studio("models/ringft.mdl") = Ring_Flight : "Ring o' flight" []
+@PointClass base(Ring_Flight) studio("models/ringre.mdl") = Ring_Regeneration : "Ring o' regeneration" []
+@PointClass base(Ring_Flight) studio("models/ringtn.mdl") = Ring_Turning : "Ring o' turning" []
+@PointClass base(Ring_Flight) studio("models/ringwb.mdl") = Ring_WaterBreathing : "Ring o' water breathing" []
+
+//
+// Entities!
+//
+
+@PointClass base(Appearflags) iconsprite("hexen2models/entities/ent_speaker.spr") color(255 128 0) = sound_ambient : "Ambient sound"
+[
+	button1(integer)   : "Next occurence (at soonest)" : 0
+	button2(integer)   : "Next occurence (at latest)" : 0
+	level(integer)     : "Volume [0-1]"
+	noise1(string)     : "Wav file top play"
+	noise2(string)     : "Wav file top play (alternate)"
+	noise3(string)     : "Wav file top play (alternate 2)"
+	soundtype(choices) : "Sound" : 4 = //9-15 Do not work properly
+	[
+		 1 : "Windmill....................ambience/windmill.wav"
+		 2 : "Sewer water sound...........ambience/drip1.wav"
+		 3 : "Dripping water, no echo.....ambience/drip2.wav"
+		 4 : "Subtle sky/wind.............ambience/wind.wav"
+		 5 : "Crickets / night sounds.....ambience/night.wav"
+		 6 : "Birds.......................ambience/birds.wav"
+		 7 : "Raven caw...................ambience/raven.wav"
+		 8 : "Rocks falling...............ambience/rockfall.wav"
+		 9 : "Lava bubble.................ambience/lava.wav"
+		10 : "Water gurgle................ambience/water.wav"
+		11 : "Metal.......................ambience/metal.wav & metal2.wav"
+		12 : "Pounding....................ambience/pounding.wav & poundin2.wav"
+		13 : "Moans and screams...........ambience/moan1.wav to moan3.wav"
+		14 : "Creaking....................ambience/creak.wav & creak2.wav"
+		15 : "Chain rattling..............ambience/rattle.wav"
+		15 : "Water gurgling..............ambience/gurgle.wav"
+	]
+	speed(choices) : "Attenuation" : 3 =
+	[
+		-1 : "ATTN_NONE (heard everywhere)"
+		1 : "ATTN_NORM (fades to zero at 1000 units)"
+		2 : "ATTN_IDLE (fades to zero at 512 units)"
+		3 : "ATTN_STATIC (fades to zero at 341 units)"
+	]
+]
+
+@PointClass base(Appearflags, Targetname) size(-10 -10 -8, 10 10 8) iconsprite("hexen2models/entities/ent_speaker.spr") color(248 215 32) = sound_maker : "Triggerable sound"
+[
+	level(integer) : "Volume [0-1]"                                  //Inky 20201125
+	noise1(string) : "Custom wav file to play (soundtype must be 0)" //Inky 20201125
+	speed(choices) : "Attenuation" : 1 =                             //Inky 20201125
+	[
+		0 : "ATTN_NONE"
+		1 : "ATTN_NORM"
+		2 : "ATTN_IDLE"
+		3 : "ATTN_STATIC"
+		4 : "ATTN_LOOP"
+	]
+	soundtype(choices) : "Sound" : 1 =
+	[
+		1 : "Bell ringing"
+		2 : "Organ music"
+		3 : "Tomb sound"
+	]
+	delay(integer) : "Delay"
+	spawnflags(Flags) =
+	[
+		1 : "For male playerclass only" : 0
+		2 : "For female playerclass only" : 0
+	]
+]
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) = target_null : "Null target" []
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) = teleport_buddha : "Praevus teleport (PoP)"
+[
+	cnt(integer) : "Cnt" : 0
+]
+
+//
+// Traps!
+//
+
+@PointClass base(Appearflags, Targetname, Target) size(-8 -8 -8, 8 8 8) = trap_fireball : "Triggerable fireball"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Once per trigger" : 0 //(aka trigger only)
+	]
+        wait(integer) : "Time between firings" : 1
+	dmg(integer) : "Damage" : 10
+]
+@PointClass base(Appearflags, Targetname, Target) size(-8 -8 -8, 8 8 8) = trap_lightning : "Lightning"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Track" : 0 //Tracks player
+		2 : "Once" : 0 //Fires only once
+	]
+	noise(choices) : "Sounds" : 2 =
+	[
+		1 : "No sound"
+		2 : "Lightning"
+	]
+	wait(integer) : "Time between shots" : 1
+	dmg(integer) : "Damage"
+	//aflag(integer) : "Radius limit" //Crashes to console when used
+]
+@PointClass base(Appearflags, Targetname, Angles) size(-8 -8 -8, 8 8 8) = trap_shooter : "Shooter"
+[
+	//spawnflags(Flags) = //These do not work, same for the spikeshooter below
+	//[
+	//	1 : "Super spike" : 0
+	//	2 : "Laser" : 0
+	//]
+	wait(integer) : "Time between shots" : 1
+	nextthink(integer) : "Delay before start"
+]
+@PointClass base(Appearflags, Targetname, Angles) size(-8 -8 -8, 8 8 8) = trap_spikeshooter : "Shooter"
+[
+	//spawnflags(Flags) =
+	//[
+	//	1 : "Super spike" : 0
+	//	2 : "Laser" : 0
+	//]
+	wait(integer) : "Time between shots" : 1
+	nextthink(integer) : "Delay before start"
+]
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) = trap_spikeshooter_spray : "Shooter"
+[
+	wait(integer) : "Time between shots" : 1
+	nextthink(integer) : "Delay before start"
+]
+
+//
+// Triggers!
+//
+
+@BaseClass base(Appearflags, Targetname, Target, KillTarget) = Trigger 
+[
+	netname(string) : "Netname"
+	aflag(integer) : "Order"
+	wait(integer) : "Wait" : 2
+	health(integer) : "Health"
+	delay(integer) : "Delay before trigger"
+	message(string) : "Message"
+	style(integer) : "Light Style"
+]
+
+@baseclass = Puzzles
+[
+	spawnflags(Flags) =
+	[
+		16 : "Remove puzzle" : 0
+		32 : "No puzzle" : 0
+	]
+	puzzle_piece_1(string) : "Puzzle Piece 1"
+	puzzle_piece_2(string) : "Puzzle Piece 2"
+	puzzle_piece_3(string) : "Puzzle Piece 3"
+	puzzle_piece_4(string) : "Puzzle Piece 4"	
+	no_puzzle_msg(string) : "No puzzle message"
+]
+
+@baseclass = Triggerflags
+[
+	spawnflags(Flags) =
+	[
+		1 : "No touch" : 0
+		2 : "For monsters only" : 0
+		4 : "Push touch" : 0
+		8 : "Deactivated" : 0
+		64 : "Light toggle" : 0
+		128 : "Light start low" : 0
+	]
+]
+
+@SolidClass base(Trigger, Puzzles) = trigger_activate : "Activate"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Once" : 0
+		2 : "Relay" : 0
+		8 : "Deactivated" : 0
+		64 : "No toggle" : 0 //Inky: prevent deactivation by activating twice
+	]
+	soundtype(choices) : "Sound" : 2 =
+	[
+		0 : "No sound"
+		1 : "Secret"
+		2 : "Bell"
+		3 : "Metal"
+	]
+]
+
+@SolidClass base(Trigger) = trigger_attack : "Trigger on weapon fire" []
+
+@SolidClass base(Trigger) = trigger_changelevel : "Changes level"
+[
+	spawnflags(Flags) =
+	[
+		1 : "No intermission" : 0
+		//2 : "End of unit" : 0
+		//4 : "End of episode" : 0
+	]
+	map(string) : "Map name"
+]
+@SolidClass base(Appearflags, Targetname, Target, KillTarget) = trigger_check : "Check" //Not triggered by players
+[
+	netname(string) : "Netname"
+	aflag(integer) : "Order"
+	health(integer) : "Health"
+	delay(integer) : "Delay before trigger"
+	message(string) : "Message"
+	style(integer) : "Light Style"
+	failtarget(target_destination) : "Fail target (PoP)"
+	wait(integer) : "Wait (PoP)"
+]
+
+@SolidClass base(Trigger) = trigger_combination_assign : "Combination assign"
+[
+	mangle(string) : "Mangle (x y z)"
+]
+
+@SolidClass base(Appearflags, Targetname, Target) = trigger_control : "Ballista control" []
+
+@SolidClass base(Trigger) = trigger_counter : "Counter"
+[
+	spawnflags(Flags) =
+	[
+		1 : "No message" : 0
+		2 : "Ordered" : 0
+		4 : "Always return" : 0
+		8 : "Deactivated" : 0
+	]
+	msg2(integer) : "Count fail message"
+	puzzle_id(target_destination) : "Count fail target"
+    count(integer) : "Number of triggers - 1"
+    mangle(string) : "Mangle (x1 x2 x3)"
+]
+@SolidClass base(Trigger) = trigger_counter_reset : "Counter reset"
+[
+	spawnflags(Flags) =
+	[
+		1 : "No touch" : 0
+		2 : "For monsters only" : 0
+		4 : "Push touch" : 0
+		8 : "Deactivated" : 0
+		16 : "Remove puzzle" : 0
+		32 : "No puzzle" : 0
+		64 : "Light toggle" : 0
+		128 : "Light start low" : 0
+	]
+]
+
+@SolidClass base(Trigger) = trigger_crosslevel : "Cross level trigger"
+[
+	spawnflags(Flags) =
+	[
+                1 : "Trigger 1" : 0
+                2 : "Trigger 2" : 0
+                4 : "Trigger 3" : 0
+                8 : "Trigger 4" : 0
+                16 : "Trigger 5" : 0
+                32 : "Trigger 6" : 0
+                64 : "Trigger 7" : 0
+                128 : "Trigger 8" : 0
+				//Inky 20210819 Extended set of cross-level triggers
+				65536 : "Trigger 9" : 0
+				//131072 Don't use. Means the entity won't show in singleplayer
+				//131072 : "Trigger 10" : 0
+				262144 : "Trigger 11" : 0
+				524288 : "Trigger 12" : 0
+				1048576 : "Trigger 13" : 0
+				2097152 : "Trigger 14" : 0
+				4194304 : "Trigger 15" : 0
+				8388608 : "Trigger 16" : 0
+	]
+	map(string) : "Map"
+]
+@SolidClass base(trigger_crosslevel) = trigger_crosslevel_target : "Crosslevel trigger target" []
+
+@SolidClass base(trigger_activate) = trigger_deactivate : "Deactivate" []
+
+@SolidClass base(Appearflags, Targetname, Target) = trigger_deathtouch : "Removes whatever it touches (PoP)"
+[
+	spawnflags(Flags) =
+	[
+                1 : "No touch" : 0
+                2 : "Any player" : 0
+                4 : "Gib" : 0
+                8 : "Deactivated" : 0
+	]
+	th_die(integer) : "Death type"
+]
+
+//Inky: 20200506 Had only Appearflags, Targetname, Target and map
+@PointClass base(Appearflags, Targetname, Target) color(128 0 0)= trigger_hub_intermission : "Trigger hub intermission (PoP)"
+[
+	delay(integer) : "Minimum duration" : 2
+	level(integer) : "Intermission #" : 11
+	map(string) : "Next map"
+	spawnflags(Flags) =
+	[
+                1 : "Keep puzzle items" : 0
+                2 : "Keep cross level triggers" : 0
+	]
+]
+
+@SolidClass base(Appearflags, Targetname) = trigger_hurt : "Hurt brush" [
+	spawnflags(Flags) =
+	[
+                1 : "Player only (PoP)" : 0
+                2 : "Monster only (PoP)" : 0
+                8 : "Deactivated (PoP)" : 0
+	]
+	dmg(integer) : "Damage" : 5
+	level(integer) : "Minimum health (PoP)"
+	wait(integer) : "Delay between damage(PoP)" : 1
+]
+
+@PointClass base(Appearflags, Targetname, Target, KillTarget) size(-8 -8 -8, 8 8 8) color(128 0 128)= trigger_interval : "Interval trigger"
+[
+	spawnflags(Flags) =
+	[
+		8 : "Deactivated" : 0
+	]
+	netname(string) : "Netname"
+	delay(integer) : "Delay before trigger"
+	wait(integer) : "Wait -defaults to 5; will be used if not button1 & button2 both set"
+	//Inky 20201204
+	button1(integer) : "minimum interval in seconds before the next firing"
+	button2(integer) : "maximum interval in seconds before the next firing"
+]
+
+@SolidClass base(Appearflags, Targetname, Target) = trigger_message_transfer : "Message transferer"
+[
+	message(string) : "Message (required)" : "139"
+]
+
+@SolidClass base(Appearflags, Targetname) = trigger_monsterjump : "Monster jumper"
+[
+	spawnflags(Flags) =
+	[
+		4 : "Deactivated (PoP)" : 0
+	]
+	speed(integer) : "Speed forward" : 200
+	height(integer) : "Speed upwards" : 200
+	wait(integer) : "Wait" : 0
+]
+
+@SolidClass base(Trigger, Triggerflags, Puzzles, CustomSound) = trigger_multiple : "Multiple trigger" //Inky: 20200408 Custom sound
+[
+	soundtype(choices) : "Sounds" : 0 =
+	[
+		0 : "No sound"
+		1 : "Secret"
+		2 : "Bell"
+		3 : "Large switch"
+	]
+]
+
+@SolidClass base(Appearflags) = trigger_no_friction : "Removes friction"
+[
+	style(integer) : "Light toggle style (33 - 63)"
+	lightvalue1(integer) : "Low light value" : 0
+	lightvalue2(integer) : "High light value" : 11
+        fadespeed(integer) : "Fade speed (0.5)" : 0
+]
+
+@PointClass base(Appearflags, Targetname, Target) color(113 71 41)= trigger_objective : "Trigger objective (PoP)"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Add objective" : 0
+		2 : "Remove objective" : 0
+	]
+	frags(integer) : "Objective (0-63)"
+]
+
+@SolidClass base(Trigger, Triggerflags, Puzzles, CustomSound) = trigger_once : "Single trigger" [] //Inky: 20200408 Custom sound
+
+@SolidClass base(Appearflags, Targetname) = trigger_push : "Push"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Push once" : 0
+		2 : "Silent" : 0 //Inky 20201018
+		4 : "Counterable" : 0 //Inky 20201018
+		8 : "Deactivated" : 0
+		16 : "Monsters only" : 0
+		32 : "Player only" : 0
+		64 : "Jump first" : 0
+	]
+	speed(integer) : "Speed of push" : 500
+	angles(string) : "Angle of push (X Y Z)"
+	mangle(string) : "Angle to force the player's facing direction to (X Y Z)"
+]
+
+@PointClass base(Appearflags, Targetname, Target, KillTarget) = trigger_quake : "Quake"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Do damage" : 0
+		2 : "Multiple" : 0
+		//8 : "Deactivated" : 0 //Quake doesn't appear to function properly after activating
+	]
+	message(string) : "Message"
+	items(integer) : "Radius of quake"
+	dmg(integer) : "Damage" : 5
+	lifespan(integer) : "Duration" : 2
+	wait(integer) : "Delay before quake" : 1
+]
+
+@PointClass base(Appearflags, Targetname, Target, KillTarget) size(-8 -8 -8, 8 8 8) color(0 192 192)= trigger_relay : "Relay"
+[
+	netname(string) : "Netname"
+	wait(integer) : "Wait"
+	delay(integer) : "Delay before trigger"
+	message(string) : "Message"
+	fadespeed(integer) : "Fade speed"
+	style(integer) : "Light Style"
+]
+
+@SolidClass base(Appearflags, Targetname) = trigger_setskill : "Set skill level (PoP)"
+[
+	noise(choices) : "Skill level" : 1 =
+	[
+		0 : "Easy"
+		1 : "Medium"
+		2 : "Hard"
+		3 : "Nightmare!"
+	]
+]
+
+@SolidClass base(Appearflags, Targetname, Target) = trigger_stop : "Trigger stop (PoP)"
+[
+	spawnflags(Flags) =
+	[
+		1 : "No touch" : 0
+	]
+	//wait(integer) : "Wait" //Crashes to console when used
+]
+
+
+@SolidClass base(Appearflags, Targetname, Target) = trigger_teleport : "Trigger teleport"
+[
+	spawnflags(flags) = 
+	[ 
+		1 : "Player only" : 0 
+		2 : "Silent" : 0
+		4 : "Deactivated" : 0
+		8 : "Deactivated" : 0
+		16 : "Chaos device behaviour" : 0
+		32 : "Everybody except player" : 0
+		64 : "Silent when off" : 0
+		128 : "Quake behavior" : 0
+	]
+]
+
+//
+// Weather!
+//
+
+@SolidClass base(Appearflags) = weather_dust : "Dusty area"
+[
+	color(integer) : "Color" : 101
+]
+
+@PointClass base(Appearflags, Targetname) = weather_lightning_end : "End of lightning bolt" []
+@PointClass base(Appearflags, Targetname, Target) = weather_lightning_start : "Beginning of lighting"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Start off" : 0
+		2 : "Thunder sound" : 0
+	]
+	noise(choices) : "Sounds" : 2 =
+	[
+		1 : "No sound"
+		2 : "Lightning"
+	]
+	wait(choices) : "Time between strikes" : -1 =
+	[
+		-1 : "Once per trigger"
+	]
+	lifespan(integer) : "Duration"
+	dmg(integer) : "Damage"
+]
+
+@SolidClass base(Appearflags) = weather_rain : "Rain area"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Fall straight" : 0
+		2 : "No splat" : 0
+	]
+	color(integer) : "Base color" : 414
+	counter(integer) : "Density" : 300
+        wait(integer) : "Frequency (0.1)" : 0
+	soundtype(choices) : "Sounds" : 1 =
+	[
+		0 : "Rain"
+		1 : "Drip"
+	]
+]
+
+@SolidClass base(Appearflags) = weather_snow : "Snow (PoP)"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Fluffy" : 0
+		2 : "Mixed" : 0
+		4 : "Half bright" : 0
+		8 : "No melt" : 0
+		16 : "In bounds" : 0
+		32 : "No translucent" : 0
+	]
+	counter(integer) : "Density" : 100
+	speed(integer) : "Falling speed" : 200
+	anglespeed(integer) : "Lateral movement" : 125
+	movedir(string) : "Blow direction (# # #)"
+]
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) = weather_sunbeam_end : "End of sunbeam" []
+@PointClass base(Appearflags, Targetname, Target) = weather_sunbeam_start : "Start of sunbeam"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Start off" : 0
+	]
+	noise(choices) : "Sounds" : 2 =
+	[
+		1 : "No sound"
+		2 : "Buzzing"
+	]
+	wait(choices) : "Time between strikes" : -1 =
+	[
+		-1 : "Once per trigger"
+	]
+	lifespan(integer) : "Duration"
+	dmg(integer) : "Damage"
+]
+
+//
+// Weapons!
+//
+//Inky: added "Effects" to the base
+@PointClass base(Appearflags, Targetname, Target, Effects) size(-8 -8 -44, 8 8 20) color(80 0 200) studio("models/w_l2_c1.mdl") = wp_weapon2 : "Weapon 2" 
+[
+	spawnflags(Flags) =
+	[
+		1 : "Floating" : 0
+	]
+	message(string) : "Message"
+	style(integer) : "Light Style"
+]
+@PointClass base(wp_weapon2) studio("models/w_l3_c1.mdl") = wp_weapon3 : "Weapon 3" []
+@PointClass base(wp_weapon2) studio("models/w_l41_c1.mdl") = wp_weapon4_head : "Weapon 4 head" []
+@PointClass base(wp_weapon2) studio("models/w_l42_c1.mdl") = wp_weapon4_staff : "Weapon 4 staff" []
+
+@SolidClass = func_group : "ericw compilers - Group of brushes for in-editor use" []
+@SolidClass = func_detail: "ericw compilers - not calculated in VIS" []
+@SolidClass = func_detail_wall : "ericw compilers - func_detail variant that doesn't split world faces." []
+@SolidClass = func_detail_illusionary: "ericw compilers - func_detail variant with no collision (players / monsters / gunfire) and doesn't split world faces." []
+
+//Inky:added still weapon 3
+@PointClass base(wp_weapon2) studio("models/w_l3_still_c1.mdl") = wp_still_weapon3 : "Still weapon 3" []
+
+//
+// Inky: Redfield's contributions
+//
+
+@PointClass base(Object) size(-16 -16 -16, 16 16 16) studio("models/redfield_largerope.mdl") = redfield_obj_largerope : "Large blowing rope" []
+//@PointClass base(Object) size(-16 -16 -16, 16 16 16) studio("models/redfield_largerope_b.mdl") = redfield_obj_largerope2 : "Large blowing rope 2" []
+@PointClass base(Object) size(-16 -16 -16, 16 16 16) studio("models/redfield_ropemount.mdl") = redfield_obj_ropemount : "Rope mount" []
+@PointClass base(Object) size(-16 -16 -16, 16 16 16) studio("models/redfield_smallrope.mdl") = redfield_obj_smallrope : "Small blowing rope" []
+
+//
+// Inky: puzzle items more easily choosable in TB
+//
+
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/lens.mdl") = puzzle_piece_lens : "Lens of Seeing"
+[
+	puzzle_id(string) : "Puzzle id" : "lens"
+	netname(string) : "Puzzle piece name" : "Lens of Seeing"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/takey.mdl") = puzzle_piece_takey : "Tailor's Key"
+[
+	puzzle_id(string) : "Puzzle id" : "takey"
+	netname(string) : "Puzzle piece name" : "Tailor's Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/trkey.mdl") = puzzle_piece_trkey : "Treasury Key"
+[
+	puzzle_id(string) : "Puzzle id" : "trkey"
+	netname(string) : "Puzzle piece name" : "Treasury Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/shovl.mdl") = puzzle_piece_shovl : "Shovel"
+[
+	puzzle_id(string) : "Puzzle id" : "shovl"
+	netname(string) : "Puzzle piece name" : "Shovel"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/sand.mdl") = puzzle_piece_sand : "Pile of Sand"
+[
+	puzzle_id(string) : "Puzzle id" : "sand"
+	netname(string) : "Puzzle piece name" : "Pile of Sand"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/stkey.mdl") = puzzle_piece_stkey : "Stable Key"
+[
+	puzzle_id(string) : "Puzzle id" : "stkey"
+	netname(string) : "Puzzle piece name" : "Stable Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/glass.mdl") = puzzle_piece_glass : "Bead of Glass"
+[
+	puzzle_id(string) : "Puzzle id" : "glass"
+	netname(string) : "Puzzle piece name" : "Bead of Glass"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/scrol.mdl") = puzzle_piece_scrol : "Disrupt Magic Scroll"
+[
+	puzzle_id(string) : "Puzzle id" : "scrol"
+	netname(string) : "Puzzle piece name" : "Disrupt Magic Scroll"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/amult.mdl") = puzzle_piece_amult : "Amulet of Hunger"
+[
+	puzzle_id(string) : "Puzzle id" : "amult"
+	netname(string) : "Puzzle piece name" : "Amulet of Hunger"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/mithl.mdl") = puzzle_piece_mithl : "Mithral Transmutation"
+[
+	puzzle_id(string) : "Puzzle id" : "mithl"
+	netname(string) : "Puzzle piece name" : "Mithral Transmutation"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/cskey.mdl") = puzzle_piece_cskey : "Castle Key"
+[
+	puzzle_id(string) : "Puzzle id" : "cskey"
+	netname(string) : "Puzzle piece name" : "Castle Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/keep1.mdl") = puzzle_piece_keep1 : "Bones of Loric"
+[
+	puzzle_id(string) : "Puzzle id" : "keep1"
+	netname(string) : "Puzzle piece name" : "Bones of Loric"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/keep3.mdl") = puzzle_piece_keep3 : "Mill Key"
+[
+	puzzle_id(string) : "Puzzle id" : "keep3"
+	netname(string) : "Puzzle piece name" : "Mill Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/keep2.mdl") = puzzle_piece_keep2 : "Bone Dust"
+[
+	puzzle_id(string) : "Puzzle id" : "keep2"
+	netname(string) : "Puzzle piece name" : "Bone Dust"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/staff.mdl") = puzzle_piece_staff : "Staff of Nefertum"
+[
+	puzzle_id(string) : "Puzzle id" : "staff"
+	netname(string) : "Puzzle piece name" : "Staff of Nefertum"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/lcrwn.mdl") = puzzle_piece_lcrwn : "Lower Crown of Egypt"
+[
+	puzzle_id(string) : "Puzzle id" : "lcrwn"
+	netname(string) : "Puzzle piece name" : "Lower Crown of Egypt"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/ucrwn.mdl") = puzzle_piece_ucrwn : "Upper Crown of Egypt"
+[
+	puzzle_id(string) : "Puzzle id" : "ucrwn"
+	netname(string) : "Puzzle piece name" : "Upper Crown of Egypt"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/ankey.mdl") = puzzle_piece_ankey : "Key of Anubis"
+[
+	puzzle_id(string) : "Puzzle id" : "ankey"
+	netname(string) : "Puzzle piece name" : "Key of Anubis"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/eyeh.mdl") = puzzle_piece_eyeh : "Eye of Horus"
+[
+	puzzle_id(string) : "Puzzle id" : "eyeh"
+	netname(string) : "Puzzle piece name" : "Eye of Horus"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/e3.mdl") = puzzle_piece_e3 : "Imsethy Canopic Jar"
+[
+	puzzle_id(string) : "Puzzle id" : "e3"
+	netname(string) : "Puzzle piece name" : "Imsethy Canopic Jar"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/s2.mdl") = puzzle_piece_s2 : "Guardian Key"
+[
+	puzzle_id(string) : "Puzzle id" : "s2"
+	netname(string) : "Puzzle piece name" : "Guardian Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/rcjem.mdl") = puzzle_piece_rcjem : "Rough Cut Gem"
+[
+	puzzle_id(string) : "Puzzle id" : "rcjem"
+	netname(string) : "Puzzle piece name" : "Rough Cut Gem"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/e6.mdl") = puzzle_piece_e6 : "Qebhsenudr Canopic Jar"
+[
+	puzzle_id(string) : "Puzzle id" : "e6"
+	netname(string) : "Puzzle piece name" : "Qebhsenudr Canopic Jar"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/e1.mdl") = puzzle_piece_e1 : "Pharaoh Key"
+[
+	puzzle_id(string) : "Puzzle id" : "e1"
+	netname(string) : "Puzzle piece name" : "Pharaoh Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/rakey.mdl") = puzzle_piece_rakey : "Key of RA"
+[
+	puzzle_id(string) : "Puzzle id" : "rakey"
+	netname(string) : "Puzzle piece name" : "Key of RA"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/stime.mdl") = puzzle_piece_stime : "Scarab of Time"
+[
+	puzzle_id(string) : "Puzzle id" : "stime"
+	netname(string) : "Puzzle piece name" : "Scarab of Time"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/scept.mdl") = puzzle_piece_scept : "Dark Pharaoh's Scepter"
+[
+	puzzle_id(string) : "Puzzle id" : "scept"
+	netname(string) : "Puzzle piece name" : "Dark Pharaoh's Scepter"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/e5.mdl") = puzzle_piece_e5 : "Duamutef Canopic Jar"
+[
+	puzzle_id(string) : "Puzzle id" : "e5"
+	netname(string) : "Puzzle piece name" : "Duamutef Canopic Jar"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/e4.mdl") = puzzle_piece_e4 : "Hapy Canopic Jar"
+[
+	puzzle_id(string) : "Puzzle id" : "e4"
+	netname(string) : "Puzzle piece name" : "Hapy Canopic Jar"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/speye.mdl") = puzzle_piece_speye : "Serpent's Eye Gem"
+[
+	puzzle_id(string) : "Puzzle id" : "speye"
+	netname(string) : "Puzzle piece name" : "Serpent's Eye Gem"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/gsphere.mdl") = puzzle_piece_gsphere : "Gold Sphere"
+[
+	puzzle_id(string) : "Puzzle id" : "gsphere"
+	netname(string) : "Puzzle piece name" : "Gold Sphere"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/prybar.mdl") = puzzle_piece_prybar : "Pry Bar"
+[
+	puzzle_id(string) : "Puzzle id" : "prybar"
+	netname(string) : "Puzzle piece name" : "Pry Bar"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/music.mdl") = puzzle_piece_music : "Sheet of Music"
+[
+	puzzle_id(string) : "Puzzle id" : "music"
+	netname(string) : "Puzzle piece name" : "Sheet of Music"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/cross.mdl") = puzzle_piece_cross : "Defiled Holy Relic"
+[
+	puzzle_id(string) : "Puzzle id" : "cross"
+	netname(string) : "Puzzle piece name" : "Defiled Holy Relic"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/holycrss.mdl") = puzzle_piece_holycrss : "Restored Holy Relic"
+[
+	puzzle_id(string) : "Puzzle id" : "holycrss"
+	netname(string) : "Puzzle piece name" : "Restored Holy Relic"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/m1.mdl") = puzzle_piece_m1 : "Ornamental Stone Key"
+[
+	puzzle_id(string) : "Puzzle id" : "m1"
+	netname(string) : "Puzzle piece name" : "Ornamental Stone Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/m2.mdl") = puzzle_piece_m2 : "Crystal Skull"
+[
+	puzzle_id(string) : "Puzzle id" : "m2"
+	netname(string) : "Puzzle piece name" : "Crystal Skull"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/m3.mdl") = puzzle_piece_m3 : "Jade Skull"
+[
+	puzzle_id(string) : "Puzzle id" : "m3"
+	netname(string) : "Puzzle piece name" : "Jade Skull"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/m4.mdl") = puzzle_piece_m4 : "Serpent's Heart"
+[
+	puzzle_id(string) : "Puzzle id" : "m4"
+	netname(string) : "Puzzle piece name" : "Serpent's Heart"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/fire.mdl") = puzzle_piece_fire : "Element of Fire"
+[
+	puzzle_id(string) : "Puzzle id" : "fire"
+	netname(string) : "Puzzle piece name" : "Element of Fire"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/air.mdl") = puzzle_piece_air : "Element of Air"
+[
+	puzzle_id(string) : "Puzzle id" : "air"
+	netname(string) : "Puzzle piece name" : "Element of Air"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/water.mdl") = puzzle_piece_water : "Element of Water"
+[
+	puzzle_id(string) : "Puzzle id" : "water"
+	netname(string) : "Puzzle piece name" : "Element of Water"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/earth.mdl") = puzzle_piece_earth : "Element of Earth"
+[
+	puzzle_id(string) : "Puzzle id" : "earth"
+	netname(string) : "Puzzle piece name" : "Element of Earth"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/r1.mdl") = puzzle_piece_r1 : "Gold Bar"
+[
+	puzzle_id(string) : "Puzzle id" : "r1"
+	netname(string) : "Puzzle piece name" : "Gold Bar"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/silver.mdl") = puzzle_piece_silver : "Silver Bar"
+[
+	puzzle_id(string) : "Puzzle id" : "silver"
+	netname(string) : "Puzzle piece name" : "Silver Bar"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/r2.mdl") = puzzle_piece_r2 : "Unpowered Crystal"
+[
+	puzzle_id(string) : "Puzzle id" : "r2"
+	netname(string) : "Puzzle piece name" : "Unpowered Crystal"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/r3.mdl") = puzzle_piece_r3 : "Crown of Kings"
+[
+	puzzle_id(string) : "Puzzle id" : "r3"
+	netname(string) : "Puzzle piece name" : "Crown of Kings"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/r4.mdl") = puzzle_piece_r4 : "Diamond Scepter"
+[
+	puzzle_id(string) : "Puzzle id" : "r4"
+	netname(string) : "Puzzle piece name" : "Diamond Scepter"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/r5.mdl") = puzzle_piece_r5 : "Powered Crystal"
+[
+	puzzle_id(string) : "Puzzle id" : "r5"
+	netname(string) : "Puzzle piece name" : "Powered Crystal"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/r6.mdl") = puzzle_piece_r6 : "Voidstone"
+[
+	puzzle_id(string) : "Puzzle id" : "r6"
+	netname(string) : "Puzzle piece name" : "Voidstone"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/r7.mdl") = puzzle_piece_r7 : "Sunstone"
+[
+	puzzle_id(string) : "Puzzle id" : "r7"
+	netname(string) : "Puzzle piece name" : "Sunstone"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/r8.mdl") = puzzle_piece_r8 : "Shadowstone"
+[
+	puzzle_id(string) : "Puzzle id" : "r8"
+	netname(string) : "Puzzle piece name" : "Shadowstone"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/soul.mdl") = puzzle_piece_soul : "Soul Key"
+[
+	puzzle_id(string) : "Puzzle id" : "soul"
+	netname(string) : "Puzzle piece name" : "Soul Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/mage.mdl") = puzzle_piece_mage : "Mage's Tome"
+[
+	puzzle_id(string) : "Puzzle id" : "mage"
+	netname(string) : "Puzzle piece name" : "Mage's Tome"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/chalice.mdl") = puzzle_piece_chalice : "Chalice of St. Eric"
+[
+	puzzle_id(string) : "Puzzle id" : "chalice"
+	netname(string) : "Puzzle piece name" : "Chalice of St. Eric"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/mask.mdl") = puzzle_piece_mask : "Burial Mask of King Lazarus"
+[
+	puzzle_id(string) : "Puzzle id" : "mask"
+	netname(string) : "Puzzle piece name" : "Burial Mask of King Lazarus"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/dagger.mdl") = puzzle_piece_dagger : "Ajanti Dagger"
+[
+	puzzle_id(string) : "Puzzle id" : "dagger"
+	netname(string) : "Puzzle piece name" : "Ajanti Dagger"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/vial.mdl") = puzzle_piece_vial : "Oil of Anointment"
+[
+	puzzle_id(string) : "Puzzle id" : "vial"
+	netname(string) : "Puzzle piece name" : "Oil of Anointment"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/goldgem.mdl") = puzzle_piece_goldgem : "Jewel of Buddha"
+[
+	puzzle_id(string) : "Puzzle id" : "goldgem"
+	netname(string) : "Puzzle piece name" : "Jewel of Buddha"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/greengem.mdl") = puzzle_piece_greengem : "Sangha Gem"
+[
+	puzzle_id(string) : "Puzzle id" : "greengem"
+	netname(string) : "Puzzle piece name" : "Sangha Gem"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/redgem.mdl") = puzzle_piece_redgem : "Dharma Jewel"
+[
+	puzzle_id(string) : "Puzzle id" : "redgem"
+	netname(string) : "Puzzle piece name" : "Dharma Jewel"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/lbudda.mdl") = puzzle_piece_lbudda : "Jade Buddha"
+[
+	puzzle_id(string) : "Puzzle id" : "lbudda"
+	netname(string) : "Puzzle piece name" : "Jade Buddha"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/dtongue.mdl") = puzzle_piece_dtongue : "Jar of Dragon Tongue"
+[
+	puzzle_id(string) : "Puzzle id" : "dtongue"
+	netname(string) : "Puzzle piece name" : "Jar of Dragon Tongue"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/scroll.mdl") = puzzle_piece_scroll : "Scroll of Enchantment"
+[
+	puzzle_id(string) : "Puzzle id" : "scroll"
+	netname(string) : "Puzzle piece name" : "Scroll of Enchantment"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/dukeseal.mdl") = puzzle_piece_dukeseal : "Duke's Seal"
+[
+	puzzle_id(string) : "Puzzle id" : "dukeseal"
+	netname(string) : "Puzzle piece name" : "Duke's Seal"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/prayer2.mdl") = puzzle_piece_prayer2 : "Prayer Wheel"
+[
+	puzzle_id(string) : "Puzzle id" : "prayer2"
+	netname(string) : "Puzzle piece name" : "Prayer Wheel"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/crosskey.mdl") = puzzle_piece_crosskey : "Cross Key"
+[
+	puzzle_id(string) : "Puzzle id" : "crosskey"
+	netname(string) : "Puzzle piece name" : "Cross Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/headkey.mdl") = puzzle_piece_headkey : "Staff of Emperor Lo Pan"
+[
+	puzzle_id(string) : "Puzzle id" : "headkey"
+	netname(string) : "Puzzle piece name" : "Staff of Emperor Lo Pan"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/tbtmask.mdl") = puzzle_piece_tbtmask : "Eyes of Buddha"
+[
+	puzzle_id(string) : "Puzzle id" : "tbtmask"
+	netname(string) : "Puzzle piece name" : "Eyes of Buddha"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/scepter.mdl") = puzzle_piece_scepter : "Vajra Scepter"
+[
+	puzzle_id(string) : "Puzzle id" : "scepter"
+	netname(string) : "Puzzle piece name" : "Vajra Scepter"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/orb.mdl") = puzzle_piece_orb : "Orb of Dakini"
+[
+	puzzle_id(string) : "Puzzle id" : "orb"
+	netname(string) : "Puzzle piece name" : "Orb of Dakini"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/magekey.mdl") = puzzle_piece_magekey : "Mage's Key"
+[
+	puzzle_id(string) : "Puzzle id" : "magekey"
+	netname(string) : "Puzzle piece name" : "Mage's Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/tienkey.mdl") = puzzle_piece_tienkey : "Tien's Key"
+[
+	puzzle_id(string) : "Puzzle id" : "tienkey"
+	netname(string) : "Puzzle piece name" : "Tien's Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/incense.mdl") = puzzle_piece_incense : "Incense of Enlightenment"
+[
+	puzzle_id(string) : "Puzzle id" : "incense"
+	netname(string) : "Puzzle piece name" : "Incense of Enlightenment"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/tbtkey.mdl") = puzzle_piece_tbtkey : "Emperor's Key"
+[
+	puzzle_id(string) : "Puzzle id" : "tbtkey"
+	netname(string) : "Puzzle piece name" : "Emperor's Key"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/orb2.mdl") = puzzle_piece_orb2 : "Sphere of Order"
+[
+	puzzle_id(string) : "Puzzle id" : "orb2"
+	netname(string) : "Puzzle piece name" : "Sphere of Order"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/bell.mdl") = puzzle_piece_bell : "Bell of Ghanta"
+[
+	puzzle_id(string) : "Puzzle id" : "bell"
+	netname(string) : "Puzzle piece name" : "Bell of Ghanta"
+]
+@PointClass base(puzzle_piece) size(-8 -8 -8, 8 8 16) studio("models/puzzle/stonet.mdl") = puzzle_piece_stonet : "Stone of Seldoot"
+[
+	puzzle_id(string) : "Puzzle id" : "stonet"
+	netname(string) : "Puzzle piece name" : "Stone of Seldoot"
+]
+
+//Inky: 20200408 Custom sounds
+@baseclass = CustomSound [
+	_noise(choices) : "Custom sound" : 0 =
+	[
+		1   : "ambience/birds.wav"
+		2   : "ambience/creak.wav"
+		3   : "ambience/creak2.wav"
+		4   : "ambience/drip1.wav"
+		5   : "ambience/drip2.wav"
+		6   : "ambience/gurgle.wav"
+		7   : "ambience/lava.wav"
+		8   : "ambience/metal.wav"
+		9   : "ambience/metal2.wav"
+		10  : "ambience/moan1.wav"
+		11  : "ambience/moan2.wav"
+		12  : "ambience/moan3.wav"
+		13  : "ambience/newhum1.wav"
+		14  : "ambience/night.wav"
+		15  : "ambience/poundin2.wav"
+		16  : "ambience/pounding.wav"
+		17  : "ambience/rain.wav"
+		18  : "ambience/rattle.wav"
+		19  : "ambience/raven.wav"
+		20  : "ambience/rockfall.wav"
+		21  : "ambience/thunder1.wav"
+		22  : "ambience/water.wav"
+		23  : "ambience/water1.wav"
+		24  : "ambience/wind.wav"
+		25  : "ambience/wind2.wav"
+		26  : "ambience/windmill.wav"
+		27  : "ambience/windpush.wav"
+		28  : "archer/arrowg.wav"
+		29  : "archer/arrowg2.wav"
+		30  : "archer/arrowr.wav"
+		31  : "archer/death.wav"
+		32  : "archer/death2.wav"
+		33  : "archer/draw.wav"
+		34  : "archer/growl.wav"
+		35  : "archer/growl2.wav"
+		36  : "archer/growl3.wav"
+		37  : "archer/growl4.wav"
+		38  : "archer/pain.wav"
+		39  : "archer/pain2.wav"
+		40  : "archer/sight.wav"
+		41  : "archer/sight2.wav"
+		42  : "assassin/arr2flsh.wav"
+		43  : "assassin/arr2wood.wav"
+		44  : "assassin/arrowbrk.wav"
+		45  : "assassin/arrowfly.wav"
+		46  : "assassin/build.wav"
+		47  : "assassin/chain.wav"
+		48  : "assassin/chn2flsh.wav"
+		49  : "assassin/chntear.wav"
+		50  : "assassin/clink.wav"
+		51  : "assassin/core.wav"
+		52  : "assassin/firebolt.wav"
+		53  : "assassin/firefblt.wav"
+		54  : "assassin/gbounce.wav"
+		55  : "assassin/pincer.wav"
+		56  : "assassin/scarab.wav"
+		57  : "assassin/scrbfly.wav"
+		58  : "assassin/spin.wav"
+		59  : "boss/wartrot1.wav"
+		60  : "boss/wartrot2.wav"
+		61  : "boss/wartrot3.wav"
+		62  : "buddha/die.wav"
+		63  : "buddha/firewall.wav"
+		64  : "buddha/laugh.wav"
+		65  : "buddha/random1.wav"
+		66  : "buddha/random2.wav"
+		67  : "buddha/recharge.wav"
+		68  : "buddha/shoot.wav"
+		69  : "buddha/sight.wav"
+		70  : "buddha/tele_out.wav"
+		71  : "buddha/teleport.wav"
+		72  : "buttons/airbut1.wav"
+		73  : "buttons/button1.wav"
+		74  : "buttons/button2.wav"
+		75  : "buttons/button3.wav"
+		76  : "buttons/button4.wav"
+		77  : "buttons/switch02.wav"
+		78  : "buttons/switch04.wav"
+		79  : "buttons/switch21.wav"
+		80  : "crusader/blizfire.wav"
+		81  : "crusader/blizzard.wav"
+		82  : "crusader/frozen.wav"
+		83  : "crusader/icefire.wav"
+		84  : "crusader/icehit.wav"
+		85  : "crusader/icewall.wav"
+		86  : "crusader/lghtn1.wav"
+		87  : "crusader/lghtn2.wav"
+		88  : "crusader/metfire.wav"
+		89  : "crusader/sunhit.wav"
+		90  : "crusader/sunhum.wav"
+		91  : "crusader/sunstart.wav"
+		92  : "crusader/tornado.wav"
+		93  : "crusader/torngo.wav"
+		94  : "death/clop.wav"
+		95  : "death/clop1.wav"
+		96  : "death/clop2.wav"
+		97  : "death/clop3.wav"
+		98  : "death/dthdie.wav"
+		99  : "death/dthfire.wav"
+		100 : "death/dthlaugh.wav"
+		101 : "death/fout.wav"
+		102 : "death/shot.wav"
+		103 : "death/victory.wav"
+		104 : "doorhead/donewell.wav"
+		105 : "doorhead/notyet.wav"
+		106 : "doors/baddoor.wav"
+		107 : "doors/basetry.wav"
+		108 : "doors/baseuse.wav"
+		109 : "doors/doorstop.wav"
+		110 : "doors/dorstart.wav"
+		111 : "doors/drawmove.wav"
+		112 : "doors/drawstrt.wav"
+		113 : "doors/gatestop.wav"
+		114 : "doors/gatestrt.wav"
+		115 : "doors/gateswng.wav"
+		116 : "doors/hydro1.wav"
+		117 : "doors/hydro2.wav"
+		118 : "doors/mtlslide.wav"
+		119 : "doors/mtlstart.wav"
+		120 : "doors/mtlstop.wav"
+		121 : "doors/penstart.wav"
+		122 : "doors/penstop.wav"
+		123 : "doors/penswing.wav"
+		124 : "doors/stonslid.wav"
+		125 : "doors/swngstop.wav"
+		126 : "doors/wdswngbg.wav"
+		127 : "doors/wdswngsm.wav"
+		128 : "doors/woodslid.wav"
+		129 : "eidolon/chrgloop.wav"
+		130 : "eidolon/chrgstrt.wav"
+		131 : "eidolon/death.wav"
+		132 : "eidolon/fakedie.wav"
+		133 : "eidolon/fireball.wav"
+		134 : "eidolon/flambrth.wav"
+		135 : "eidolon/flamend.wav"
+		136 : "eidolon/flamstrt.wav"
+		137 : "eidolon/growl.wav"
+		138 : "eidolon/orbhurt.wav"
+		139 : "eidolon/orbpulse.wav"
+		140 : "eidolon/orbxpld.wav"
+		141 : "eidolon/pain.wav"
+		142 : "eidolon/roar.wav"
+		143 : "eidolon/spell.wav"
+		144 : "eidolon/stomp.wav"
+		145 : "enforcer/death1.wav"
+		146 : "enforcer/enfire.wav"
+		147 : "enforcer/enfstop.wav"
+		148 : "enforcer/idle1.wav"
+		149 : "enforcer/pain1.wav"
+		150 : "enforcer/pain2.wav"
+		151 : "enforcer/sight1.wav"
+		152 : "enforcer/sight2.wav"
+		153 : "enforcer/sight3.wav"
+		154 : "enforcer/sight4.wav"
+		155 : "ezzo/grunt.wav"
+		156 : "famine/clop1.wav"
+		157 : "famine/clop2.wav"
+		158 : "famine/clop3.wav"
+		159 : "famine/die.wav"
+		160 : "famine/flashdie.wav"
+		161 : "famine/laugh.wav"
+		162 : "famine/pull.wav"
+		163 : "famine/shot.wav"
+		164 : "famine/snort.wav"
+		165 : "famine/whinny.wav"
+		166 : "fangel/ambi1.wav"
+		167 : "fangel/ambi2.wav"
+		168 : "fangel/death.wav"
+		169 : "fangel/death2.wav"
+		170 : "fangel/deflect.wav"
+		171 : "fangel/fly.wav"
+		172 : "fangel/hand.wav"
+		173 : "fangel/pain.wav"
+		174 : "fangel/pain2.wav"
+		175 : "fangel/wing.wav"
+		176 : "fx/bonebrk.wav"
+		177 : "fx/claybrk.wav"
+		178 : "fx/clothbrk.wav"
+		179 : "fx/draglion.wav"
+		180 : "fx/glassbrk.wav"
+		181 : "fx/leafbrk.wav"
+		182 : "fx/metalbrk.wav"
+		183 : "fx/quake.wav"
+		184 : "fx/rejoice.wav"
+		185 : "fx/shiva.wav"
+		186 : "fx/snowwind.wav"
+		187 : "fx/thngland.wav"
+		188 : "fx/wallbrk.wav"
+		189 : "fx/woodbrk.wav"
+		190 : "golem/awaken.wav"
+		191 : "golem/dthgroan.wav"
+		192 : "golem/gbcharge.wav"
+		193 : "golem/gbfire.wav"
+		194 : "golem/mtlfall.wav"
+		195 : "golem/mtlpain.wav"
+		196 : "golem/slide.wav"
+		197 : "golem/step.wav"
+		198 : "golem/stnfall.wav"
+		199 : "golem/stnpain.wav"
+		200 : "golem/stomp.wav"
+		201 : "golem/swing.wav"
+		202 : "hydra/die.wav"
+		203 : "hydra/open.wav"
+		204 : "hydra/pain.wav"
+		205 : "hydra/spit.wav"
+		206 : "hydra/swim.wav"
+		207 : "hydra/tent.wav"
+		208 : "hydra/turn-b.wav"
+		209 : "hydra/turn-s.wav"
+		210 : "imp/die.wav"
+		211 : "imp/diebig.wav"
+		212 : "imp/fireball.wav"
+		213 : "imp/fly.wav"
+		214 : "imp/flybig.wav"
+		215 : "imp/shard.wav"
+		216 : "imp/swoop.wav"
+		217 : "imp/swoopbig.wav"
+		218 : "imp/swoophit.wav"
+		219 : "imp/up.wav"
+		220 : "imp/upbig.wav"
+		221 : "items/armrpkup.wav"
+		222 : "items/artpkup.wav"
+		223 : "items/inv2.wav"
+		224 : "items/itempkup.wav"
+		225 : "items/itmspawn.wav"
+		226 : "items/r_item2.wav"
+		227 : "items/ringpkup.wav"
+		228 : "medusa/attack1.wav"
+		229 : "medusa/attack2.wav"
+		230 : "medusa/death.wav"
+		231 : "medusa/hiss.wav"
+		232 : "medusa/hitplayr.wav"
+		233 : "medusa/pain.wav"
+		234 : "medusa/rattle.wav"
+		235 : "medusa/sight.wav"
+		236 : "medusa/stoned.wav"
+		237 : "mezzo/attack.wav"
+		238 : "mezzo/die.wav"
+		239 : "mezzo/growl.wav"
+		240 : "mezzo/pain.wav"
+		241 : "mezzo/reflect.wav"
+		242 : "mezzo/roar.wav"
+		243 : "mezzo/skid.wav"
+		244 : "mezzo/slam.wav"
+		245 : "mezzo/snort.wav"
+		246 : "misc/Beep1.wav"
+		247 : "misc/barmovdn.wav"
+		248 : "misc/barmovup.wav"
+		249 : "misc/bellring.wav"
+		250 : "misc/bshatter.wav"
+		251 : "misc/camera.wav"
+		252 : "misc/catdrop.wav"
+		253 : "misc/catlnch.wav"
+		254 : "misc/catreset.wav"
+		255 : "misc/combust.wav"
+		256 : "misc/comm.wav"
+		257 : "misc/cubehum.wav"
+		258 : "misc/decomp.wav"
+		259 : "misc/drip.wav"
+		260 : "misc/fburn_bg.wav"
+		261 : "misc/fburn_md.wav"
+		262 : "misc/fburn_sm.wav"
+		263 : "misc/fout.wav"
+		264 : "misc/hith2o.wav"
+		265 : "misc/icestatx.wav"
+		266 : "misc/invmove.wav"
+		267 : "misc/invuse.wav"
+		268 : "misc/lighthit.wav"
+		269 : "misc/null.wav"
+		270 : "misc/organ.wav"
+		271 : "misc/pulse.wav"
+		272 : "misc/pushmetl.wav"
+		273 : "misc/pushston.wav"
+		274 : "misc/pushwood.wav"
+		275 : "misc/rubble.wav"
+		276 : "misc/secret.wav"
+		277 : "misc/sheep1.wav"
+		278 : "misc/sheep2.wav"
+		279 : "misc/sheep3.wav"
+		280 : "misc/sheepfly.wav"
+		281 : "misc/squeak.wav"
+		282 : "misc/sshatter.wav"
+		283 : "misc/teleprt1.wav"
+		284 : "misc/teleprt2.wav"
+		285 : "misc/teleprt3.wav"
+		286 : "misc/teleprt4.wav"
+		287 : "misc/teleprt5.wav"
+		288 : "misc/tink.wav"
+		289 : "misc/tomb.wav"
+		290 : "misc/trigger1.wav"
+		291 : "misc/warning.wav"
+		292 : "misc/whoosh.wav"
+		293 : "mummy/bite.wav"
+		294 : "mummy/crawl.wav"
+		295 : "mummy/die.wav"
+		296 : "mummy/die2.wav"
+		297 : "mummy/limbloss.wav"
+		298 : "mummy/mislfire.wav"
+		299 : "mummy/moan.wav"
+		300 : "mummy/moan2.wav"
+		301 : "mummy/pain.wav"
+		302 : "mummy/pain2.wav"
+		303 : "mummy/sight.wav"
+		304 : "mummy/sight2.wav"
+		305 : "mummy/slide.wav"
+		306 : "mummy/step.wav"
+		307 : "mummy/tap.wav"
+		308 : "necro/bonefnrm.wav"
+		309 : "necro/bonefpow.wav"
+		310 : "necro/bonenhit.wav"
+		311 : "necro/bonenwal.wav"
+		312 : "necro/bonephit.wav"
+		313 : "necro/mmfire.wav"
+		314 : "paladin/axblade.wav"
+		315 : "paladin/axgen.wav"
+		316 : "paladin/axgenpr.wav"
+		317 : "paladin/axric1.wav"
+		318 : "paladin/devine.wav"
+		319 : "paladin/purfire.wav"
+		320 : "paladin/purfireb.wav"
+		321 : "pent/die.wav"
+		322 : "pent/fire.wav"
+		323 : "pent/jump.wav"
+		324 : "pent/latch.wav"
+		325 : "pent/pain.wav"
+		326 : "pest/buzz.wav"
+		327 : "pest/charge.wav"
+		328 : "pest/clop1.wav"
+		329 : "pest/clop2.wav"
+		330 : "pest/clop3.wav"
+		331 : "pest/die.wav"
+		332 : "pest/gallop.wav"
+		333 : "pest/hivehit.wav"
+		334 : "pest/laugh.wav"
+		335 : "pest/sight.wav"
+		336 : "pest/snort.wav"
+		337 : "pest/snort2.wav"
+		338 : "pest/sting1.wav"
+		339 : "pest/sting2.wav"
+		340 : "pest/sting3.wav"
+		341 : "pest/xbowfire.wav"
+		342 : "pest/xbowhit.wav"
+		343 : "plats/boldroll.wav"
+		344 : "plats/boldstop.wav"
+		345 : "plats/chainplt1.wav"
+		346 : "plats/chainplt2.wav"
+		347 : "plats/guiltin1.wav"
+		348 : "plats/guiltin2.wav"
+		349 : "plats/medplat1.wav"
+		350 : "plats/medplat2.wav"
+		351 : "plats/plat1.wav"
+		352 : "plats/plat2.wav"
+		353 : "plats/platslid.wav"
+		354 : "plats/platstp.wav"
+		355 : "plats/pulyplt1.wav"
+		356 : "plats/pulyplt2.wav"
+		357 : "plats/pwheel1.wav"
+		358 : "plats/pwheel2.wav"
+		359 : "plats/train1.wav"
+		360 : "plats/train2.wav"
+		361 : "player/assdie1.wav"
+		362 : "player/assdie2.wav"
+		363 : "player/assdieh2.wav"
+		364 : "player/assdrown.wav"
+		365 : "player/assgasp1.wav"
+		366 : "player/assgasp2.wav"
+		367 : "player/assjmp.wav"
+		368 : "player/asslnd.wav"
+		369 : "player/asspain1.wav"
+		370 : "player/asspain2.wav"
+		371 : "player/decap.wav"
+		372 : "player/gib1.wav"
+		373 : "player/gib2.wav"
+		374 : "player/h2ojmp.wav"
+		375 : "player/land.wav"
+		376 : "player/leave.wav"
+		377 : "player/megagib.wav"
+		378 : "player/paldie1.wav"
+		379 : "player/paldie2.wav"
+		380 : "player/paldieh2.wav"
+		381 : "player/paldrown.wav"
+		382 : "player/palgasp1.wav"
+		383 : "player/palgasp2.wav"
+		384 : "player/paljmp.wav"
+		385 : "player/pallnd.wav"
+		386 : "player/palpain1.wav"
+		387 : "player/palpain2.wav"
+		388 : "player/slimbrn1.wav"
+		389 : "player/swim1.wav"
+		390 : "player/swim2.wav"
+		391 : "player/telefrag.wav"
+		392 : "raven/blast.wav"
+		393 : "raven/death.wav"
+		394 : "raven/douse.wav"
+		395 : "raven/fire1.wav"
+		396 : "raven/flame1.wav"
+		397 : "raven/in_hurt.wav"
+		398 : "raven/inh2o.wav"
+		399 : "raven/inlava.wav"
+		400 : "raven/kiltorch.wav"
+		401 : "raven/lightng1.wav"
+		402 : "raven/littorch.wav"
+		403 : "raven/menu1.wav"
+		404 : "raven/menu2.wav"
+		405 : "raven/menu3.wav"
+		406 : "raven/nevermor.wav"
+		407 : "raven/outwater.wav"
+		408 : "raven/ravengo.wav"
+		409 : "raven/rfire1.wav"
+		410 : "raven/rfire2.wav"
+		411 : "raven/soul.wav"
+		412 : "raven/split.wav"
+		413 : "raven/squawk.wav"
+		414 : "raven/squawk2.wav"
+		415 : "raven/use_plaq.wav"
+		416 : "raven/wallbrk.wav"
+		417 : "rj/steve.wav"
+		418 : "scorpion/awaken.wav"
+		419 : "scorpion/clawsnap.wav"
+		420 : "scorpion/death.wav"
+		421 : "scorpion/pain.wav"
+		422 : "scorpion/tailwhip.wav"
+		423 : "scorpion/walk.wav"
+		424 : "skullwiz/blinkin.wav"
+		425 : "skullwiz/blinkout.wav"
+		426 : "skullwiz/blinkspk.wav"
+		427 : "skullwiz/blnkspk2.wav"
+		428 : "skullwiz/death.wav"
+		429 : "skullwiz/death2.wav"
+		430 : "skullwiz/firemisl.wav"
+		431 : "skullwiz/gate.wav"
+		432 : "skullwiz/gatespk.wav"
+		433 : "skullwiz/growl.wav"
+		434 : "skullwiz/growl2.wav"
+		435 : "skullwiz/pain.wav"
+		436 : "skullwiz/pain2.wav"
+		437 : "skullwiz/push.wav"
+		438 : "skullwiz/scream.wav"
+		439 : "skullwiz/scream2.wav"
+		440 : "snake/attack.wav"
+		441 : "snake/hiss.wav"
+		442 : "snake/life.wav"
+		443 : "snake/wake.wav"
+		444 : "spider/bite.wav"
+		445 : "spider/death.wav"
+		446 : "spider/pain.wav"
+		447 : "spider/scuttle.wav"
+		448 : "spider/step1.wav"
+		449 : "spider/step2.wav"
+		450 : "spider/step3.wav"
+		451 : "succubus/acidfire.wav"
+		452 : "succubus/acidhit.wav"
+		453 : "succubus/acidpfir.wav"
+		454 : "succubus/blobexpl.wav"
+		455 : "succubus/brnbounce.wav"
+		456 : "succubus/brnfire.wav"
+		457 : "succubus/brnhit.wav"
+		458 : "succubus/brnwall.wav"
+		459 : "succubus/buzz.wav"
+		460 : "succubus/buzz2.wav"
+		461 : "succubus/dropfizz.wav"
+		462 : "succubus/endhisss.wav"
+		463 : "succubus/firecirc.wav"
+		464 : "succubus/firelbal.wav"
+		465 : "succubus/firelght.wav"
+		466 : "succubus/firelpow.wav"
+		467 : "succubus/flamend.wav"
+		468 : "succubus/flamloop.wav"
+		469 : "succubus/flampow.wav"
+		470 : "succubus/flamstrt.wav"
+		471 : "succubus/fwoomp.wav"
+		472 : "succubus/gasss.wav"
+		473 : "succubus/hisss.wav"
+		474 : "t_heads/chat7b.wav"
+		475 : "t_heads/default.wav"
+		476 : "t_heads/halt1.wav"
+		477 : "t_heads/hey.wav"
+		478 : "t_heads/overhere.wav"
+		479 : "t_heads/you.wav"
+		480 : "war/die.wav"
+		481 : "war/fire.wav"
+		482 : "war/fire_big.wav"
+		483 : "war/laugh.wav"
+		484 : "war/laugh_sm.wav"
+		485 : "war/whinbig.wav"
+		486 : "war/whinny.wav"
+		487 : "weapons/ammopkup.wav"
+		488 : "weapons/ballista.wav"
+		489 : "weapons/ballwind.wav"
+		490 : "weapons/drain.wav"
+		491 : "weapons/exphuge.wav"
+		492 : "weapons/explode.wav"
+		493 : "weapons/expsmall.wav"
+		494 : "weapons/fbfire.wav"
+		495 : "weapons/gaunt1.wav"
+		496 : "weapons/gauntht1.wav"
+		497 : "weapons/gauntht2.wav"
+		498 : "weapons/grenade.wav"
+		499 : "weapons/hithurt2.wav"
+		500 : "weapons/hitwall.wav"
+		501 : "weapons/met2flsh.wav"
+		502 : "weapons/met2met.wav"
+		503 : "weapons/met2stn.wav"
+		504 : "weapons/met2wd.wav"
+		505 : "weapons/r_exp3.wav"
+		506 : "weapons/ric1.wav"
+		507 : "weapons/ric2.wav"
+		508 : "weapons/ric3.wav"
+		509 : "weapons/slash.wav"
+		510 : "weapons/spike2.wav"
+		511 : "weapons/tink1.wav"
+		512 : "weapons/unsheath.wav"
+		513 : "weapons/vorpblst.wav"
+		514 : "weapons/vorpht1.wav"
+		515 : "weapons/vorpht2.wav"
+		516 : "weapons/vorppwr.wav"
+		517 : "weapons/vorpswng.wav"
+		518 : "weapons/vorpturn.wav"
+		519 : "weapons/weappkup.wav"
+		520 : "yakman/attack.wav"
+		521 : "yakman/die.wav"
+		522 : "yakman/growl.wav"
+		523 : "yakman/grunt.wav"
+		524 : "yakman/hoof.wav"
+		525 : "yakman/icespell.wav"
+		526 : "yakman/pain.wav"
+		527 : "yakman/reflect.wav"
+		528 : "yakman/roar.wav"
+		529 : "yakman/skid.wav"
+		530 : "yakman/slam.wav"
+		531 : "yakman/snort.wav"
+		532 : "yakman/snort1.wav"
+		533 : "yakman/snort2.wav"
+	]
+]
+
+//Inky: factoring as a base class for easier reuse
+@baseclass = ThingType [ 
+	thingtype(choices) : "Material type" : -1 =
+	[
+		-1 : "None"
+		0 : "Glass"
+		1 : "Grey stone"
+		2 : "Wood"
+		3 : "Metal"
+		4 : "Flesh"
+		5 : "Fire"
+		6 : "Clay"
+		7 : "Leaves"
+		8 : "Hay"
+		9 : "Brown stone"
+		10 : "Cloth"
+		11 : "Wood & leaf"
+		12 : "Wood & metal"
+		13 : "Wood & stone"
+		14 : "Metal & stone"
+		15 : "Metal & cloth"
+		16 : "Spider web"
+		17 : "Glass"
+		18 : "Ice"
+		19 : "Clear glass"
+		20 : "Red glass"
+		21 : "Acid"
+		22 : "Meteor"
+		23 : "Green flesh"
+		24 : "Bone"
+	]
+]
+
+//Inky: Effects
+@baseclass = Effects[
+	effects(Flags) =
+	[
+		1 : "Bright field" : 0
+		2 : "Muzzle flash" : 0
+		4 : "Bright light" : 0
+		6 : "Torch light" : 0
+		8 : "Dim light" : 0
+		16 : "Dark light" : 0
+		32 : "Dark field" : 0
+		64 : "Light" : 0
+		128 : "No draw" : 0
+		256 : "Tex stop first" : 0
+		528 : "Tex stop last" : 0
+	]
+]
+
+@PointClass base(PlayerClass) = info_player_box : "Player box" [] //Inky: for debugging purposes in TB
+
+//Inky: 20200409 class-dependent armors
+@PointClass base(Item) studio("models/_tb_armor05.mdl") = item_armor_05 : "Armor 5%" []
+@PointClass base(Item) studio("models/_tb_armor10.mdl") = item_armor_10 : "Armor 10%" []
+@PointClass base(Item) studio("models/_tb_armor15.mdl") = item_armor_15 : "Armor 15%" []
+@PointClass base(Item) studio("models/_tb_armor25.mdl") = item_armor_25 : "Armor 25%" []
+
+@PointClass base(Object) size(-32 -32 -0, 32 32 120) studio("models/throne.mdl") = obj_throne : "Skeleton's throne (PoP)" [] //Inky: was missing
+
+//Inky: 20191228
+@PointClass base(Object) size(-20 -20 -0, 20 20 80) studio("models/samurai2.mdl") = obj_samurai2 : "Samurai statue (PoP)"
+[
+	frame(integer) : "Pose" : 1
+]
+
+//Inky: 20200221 position transfer
+@PointClass base(Appearflags, Targetname, Target) = trigger_origin_transfer : "Position transferer"
+[
+	delay(integer) : "Delay before transfer"
+	message(string) : "Message (optional)" : "139"
+	movedir(string) : "Offset position '# # #'"
+]
+
+//Inky: 20200223 ally vision
+@PointClass base(Targetname, Target) = trigger_ally_vision : "Ally vision"
+[
+	message(string) : "Message (optional)" : "139"
+]
+
+@SolidClass base(Appearflags, Targetname) = func_doomdoor : "Slice of a door à la Doom upper-pegged door (target the starting slice)"
+[
+	angle(integer) : "Move direction"
+	wait(integer) : "Delay before closing" : -1
+	spawnflags(Flags) =
+	[
+		1 : "Start open" : 0
+	]
+]
+// Implementés dans le code (copiés de Unholy) donc théoriquement utilisables, mais pas encore testés en pratique dans une map Hexen II
+@SolidClass base(Appearflags, Targetname) = func_playerclip : "A bbox entity which is solid for the player only" []
+//@PointClass base(Appearflags, Targetname) size(-8 -8 -8,8 8 8) color(255 128 64) = func_playtrack : "Plays a CD track/music file"
+//[
+//	sounds(integer) : "CD track number"
+//]
+ 
+@PointClass color(41 189 41) = trigger_setproperty : "Set targets' property"
+[
+	targetname(target_source) : "Name"
+	target(target_destination) : "Target (special values: player, other, activator, activator.goalentity)"
+	delay(integer) : "Delay before acting"
+	netname(choices) : "Property name" =
+	[
+		"angles"        : "use angles to specify a value"
+		"activate"      : "use map: (+ yes) (- no) (/ toggle)"
+		"button1"       : "use level to specify a frame #"
+		"button2"       : "use level to specify a frame #"
+		"camera_time"   : "use level to tell in how much seconds camera mode exits"
+		"cnt_polymorph" : "use level to set the count"
+		"cnt_tome"      : "use level to set the count"
+		"cnt_white"     : "use level to set the count"
+		"drawflags"     : "add/remove the 'level' value with 'map' == +/-"
+		"effects"       : "add/remove the 'level' value with 'map' == +/-"
+		"enemy"         : "use msg3 to specify a target name or 'player'"
+		"flags"         : "add/remove the 'level' value with 'map' == +/-"
+		"frame"         : "use level to specify a value"
+		"health"        : "use level to specify a value"
+		"level"         : "use level to specify a value"
+		"message"       : "use level to set the line # in strings.txt"
+		"movechain"     : "use msg3 to specify a target name"
+		"netname"      : "use msg3 to specify a value"
+		"nextthink"     : "use level to specify a value in seconds from now"
+		"noise1"        : "use msg3 to specify a value"
+		"origin"        : "automatically uses this entity's origin"
+		"owner"         : "use msg3 to specify a target name"
+		"skin"          : "use level to specify a value"
+		"speed"         : "use level to specify a value"
+		"solid"         : "use level to specify a value"
+		"spawnflags"    : "add/remove the 'level' value with 'map' == +/-"
+		"takedamage"    : "use level to set the inflicted damage value"
+		"target"        : "use msg3 to specify a new target; special values: other, activator, activator.goalentity"
+		"targetname"    : "use msg3 to specify a new target name"
+		"velocity"      : "use angles to specify a value"
+		"wait"          : "use level to specify a value"
+	]
+	map(choices) : "Add/subtract instructions" =
+	[
+		"+" : "Add value"
+		"-" : "Subtract value"
+	]
+	level(integer) : "Value for a float property"
+	msg3(string)   : "Value for a string property"
+	angles(string) : "X Y Z value for a vector property"
+	spawnflags(Flags) =
+	[
+		1 : "Target netname" : 0
+		8 : "Deactivated" : 0
+	]
+]
+
+@SolidClass base(Appearflags, Targetname, Target) = trigger_teleport_stealth : "Stealth trigger teleport (use as a grid-aligned cuboid)"
+[
+	close_target(target_destination) : "Reverse target"
+	spawnflags(flags) = 
+	[ 
+		8 : "Deactivated" : 0
+	]
+]
+
+@SolidClass base(Trigger) = trigger_changelevel_stealth : "Changes level smoothly"
+[
+	spawnflags(flags) = 
+	[ 
+		8 : "Deactivated" : 0
+	]
+	map(string) : "Destination map name"
+	target(string) : "A trigger_changelevel_stealth' targetname at destination"
+]
+
+@PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) color(255 192 255) = trigger_wanderlust : "Wanderlust trigger"
+[
+	target(target_destination) : "Target"
+	spawnflags(Flags) =
+	[
+		1 : "Target netname" : 0
+		2 : "Target classname" : 0
+		8 : "Deactivated" : 0
+		128 : "Show wanderlust (debug)" : 0
+	]
+	failchance(integer) : "Chance that trigger may fail to change a target's current destination (0 - 100%)"
+	speed(integer) :      "If set, overrides all its targets' speed"
+	monster_duration(integer) : "The distance the wanderlust entity is put away from the wanderer" : 256
+	button1(integer) : "minimum interval in seconds before the next firing" : 3
+	button2(integer) : "maximum interval in seconds before the next firing" : 6
+]
+
+@PointClass base(Appearflags, Target, Targetname) size(-8 -8 -8, 8 8 8) color(128 128 0) = trigger_random : "Randomly triggers only one of its targets (give them a .mass to weight the chances of being chosen)"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Consume" : 0
+		8 : "Deactivated" : 0
+	]
+]
+
+@PointClass size(-8 -8 -8, 8 8 8) model ({"path": model, "scale": scale, "skin": skin, "frame": frame })= misc_model : "External model"
+[
+	abslight(integer) : "Absolute light value"
+	model(string):   "External model path"
+	scale(integer):   "Scale"
+	skin(integer):   "Skin"
+	frame(integer):   "Frame"
+	button0(integer) : "Starting animation frame # within the [button1-button2] range (button1 by default)"
+	button1(integer) : "First animation frame"
+	button2(integer) : "Last animation frame"
+	frags(integer) : "Animation frames duration; default 0.05" : 0.05
+	spawnflags(Flags) =
+	[
+		1 : "Only once" : 0
+		2 : "Anim back & forth" : 0
+	]
+]
+
+//
+//Inky: Quake monsters!
+//
+@PointClass base(Monster) size(-32 -32 -24, 32 32 64) studio("models/fiend.mdl") = monster_fiend : "Fiend" []
+
+//
+//Inky: Additional custom entities
+//
+@PointClass base(Object) size(-10 -24 0,10 24 60) model({"path": "models/sign_left.mdl", "skin": skin}) = obj_sign_left : "Wooden sign pointing to the left" []
+@PointClass base(Object) size(-10 -24 0,10 24 60) model({"path": "models/sign_right.mdl", "skin": skin}) = obj_sign_right : "Wooden sign pointing to the right" []
+//Inky 20201122 Courtesy of Mathuz:
+@PointClass base(Appearflags) size(-5 -5 0, 5 5 20) model("models/tankard.mdl") = obj_tankard : "A tavern tankard" []
+@PointClass base(Appearflags) size(-5 -5 0, 5 5 16) model("models/goblet.mdl") = obj_goblet : "A tavern goblet" []
+@PointClass base(Appearflags) size(-8 -8 0, 8 8 20) model("models/cleaver.mdl") = obj_cleaver : "A bloody kitchen/tavern cleaver" []
+
+@SolidClass base(Trigger) = trigger_upset : "Makes monsters mad at its target"
+[
+	spawnflags(flags) = 
+	[ 
+		8 : "Deactivated" : 0
+	]
+	target(string) : "A target to be mad at (if not set: the player)"
+]
+
+@SolidClass base(Angle, Appearflags, Target, Targetname) = trigger_centerprint : "Trigger: Centerprint"
+[
+	spawnflags(flags) =
+	[
+		1: "Relay" : 0
+		2: "Plaque" : 0
+	]
+	message(string) : "Message to display across the screen"
+	wait(integer) : "Duration"
+]
+
+@PointClass base(Appearflags, Targetname, Target) color(128 210 128) = func_lightstyle : "Global lightstyle changer"
+[
+	netname(string) : "Brightness animation pattern"
+	style(integer) : "Lightstyle to change [0-11] vanilla [12-24] custom" : 0
+]
+
+@PointClass base(Appearflags, Targetname) color(255 170 255) model ({"path": model}) = misc_modelpimp : "Model properties"
+[
+	model(string) : "Model to pimp"
+	spawnflags(flags) =
+	[
+		1: "Spin" : 0
+		2: "Float" : 0
+		4: "Glow orb" : 0
+		8: "Cast light" : 0
+	]
+	flags(flags) =
+	[
+		1: "Rocket smoke trail" : 0
+		2: "Grenade smoke trail" : 0
+		4: "Gib long blood trail" : 0
+		8: "Rotate" : 0
+		16: "Scrag double green trail" : 0
+		32: "Zombie gib short blood trail" : 0
+		64: "Hellknight orange split trail" : 0
+		128: "Vore purple trail" : 0
+		256: "Fireball" : 0
+		512: "Ice trail" : 0
+		1024: "Mipmap" : 0
+		2048: "Ink spit" : 0
+		4096: "Transparent sprite" : 0
+		8192: "Vertical spray" : 0
+		16384: "Holey (fence) texture" : 0
+		32768: "Translucent" : 0
+		65536: "Always facing" : 0
+		131072: "Bottom & top trail" : 0
+		262144: "Slow staff move" : 0
+		524288: "Blue/white magic drip" : 0
+		1048576: "Bone shards drip" : 0
+		2097152: "Scarab dust" : 0
+		4194304: "Acid ball" : 0
+		8388608: "Blood rain" : 0
+		16777216: "Far mipmap" : 0
+	]
+	glow_color(string) : "Color for the glow and/or illumination"
+	abslight(integer)  : "Glow alpha transparency" : 0.75
+	view_ofs(string)   : "Glow offset relatively to model origin (x y z)" : "0 0 0"
+	health(integer)    : "Glow radius" : 20
+	max_health(integer): "Cast light radius" : 200
+	wait(integer)      : "Refresh rate" : 0.5
+	style(choices) : "Style (32-63 for groups)" : 0 =
+	[
+		0 : "Normal"
+		1 : "Soft flicker"
+		6 : "Faster flicker"
+
+		4 : "Low falloff"
+
+		5 : "Pulse"
+		2 : "Slow pulse in & out"
+		11 : "Quick pulse in & out"
+
+		3 : "Erratic pulse & flicker A"
+		7 : "Erratic pulse & flicker B"
+		8 : "Erratic pulse & flicker C"
+		9 : "Slow blink"
+		10 : "Fluorescent flicker"
+		
+		12 : "Custom style 1"
+		13 : "Custom style 2"
+		14 : "Custom style 3"
+		15 : "Custom style 4"
+		16 : "Custom style 5"
+		17 : "Custom style 6"
+		18 : "Custom style 7"
+		19 : "Custom style 8"
+		20 : "Custom style 9"
+		21 : "Custom style 10"
+		22 : "Custom style 11"
+		23 : "Custom style 12"
+		24 : "Custom style 13"
+		
+		25 : "MLS_FULLBRIGHT"
+		26 : "MLS_POWERMODE"
+		27 : "MLS_TORCH"
+		28 : "MLS_FIREFLICKER"
+		29 : "MLS_CRYSTALGOLEM"
+	]
+]
+
+@PointClass base(Appearflags, Targetname) size(-16 -16 0, 16 16 56) color(255 64 64)= func_monsterspawner_nk : "spawner"
+[
+	spawnflags(Flags) =
+	[
+		1 : "Quiet" : 0
+		2 : "Big teleport effect" : 0
+		4 : "Angry at player" : 0
+		//131072 Don't use. Means the entity won't show in singleplayer
+	]
+	headmodel(choices) : "Monster class" =
+	[
+		"monster_archer"              : "Archer"                     
+		"monster_archer_ice"          : "Archer (Ice)"               
+		"monster_fallen_angel"        : "Fallen angel"
+		"monster_imp_fire"            : "Imp (Fire)"                 
+		"monster_imp_ice"             : "Imp (Ice)"                  
+		"monster_scorpion_yellow"     : "Scorpion (Yellow)"          
+		"monster_scorpion_black"      : "Scorpion (Black - tougher)" 
+		"monster_skull_wizard"        : "Skull Wizard"               
+		"monster_spider_yellow_small" : "Spider (black small)"       
+		"monster_spider_yellow_large" : "Spider (black large)"       
+		"monster_spider_red_small"    : "Spider (green small)"       
+		"monster_spider_red_large"    : "Spider (green large)"       
+		"monster_weresnowleopard"     : "Wereleopard"                
+		"monster_weretiger"           : "Weretiger"                  
+		"monster_yakman"              : "Yakman"                     
+	]
+	target(string): "Targets to fire when spawning a new monster. Useful for setting up specific properties for it thanks to trigger_setproperty with target = activator.goalentity"
+]


### PR DESCRIPTION
* Base documentation (still mostly empty) for the supported impulse commands
* Fix to prevent risks of a runaway loop between chunk_death and SUB_UseTargets
* Fix for possible global 'player' variable pointer loss
* Fix for returning the v_cshift value to normal upon reload after drown in a liquid train
* God mode & infinite mana cheat codes now distinct (impulse 9 vs impulse 19)
* Added notes about self.decap meaning in plats_mp.hc (a long lasting puzzling crap)
* Spider death slightly changed to help avoiding runaway loops
* SUB_UseTargets fixed to prevent runaway loops in case of set blank target
* trigger_wanderlust more simple and robust
* trigger_setproperty now able to set an entity's netname